### PR TITLE
Future articles

### DIFF
--- a/vendor/plugins/future_articles_sidebar/Rakefile
+++ b/vendor/plugins/future_articles_sidebar/Rakefile
@@ -1,0 +1,22 @@
+require 'rake'
+require 'rake/testtask'
+require 'rake/rdoctask'
+
+desc 'Default: run unit tests.'
+task :default => :test
+
+desc 'Test the future_articles_sidebar plugin.'
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'lib'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
+end
+
+desc 'Generate documentation for the future_articles_sidebar plugin.'
+Rake::RDocTask.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'FutureArticlesSidebar'
+  rdoc.options << '--line-numbers' << '--inline-source'
+  rdoc.rdoc_files.include('README')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end

--- a/vendor/plugins/future_articles_sidebar/init.rb
+++ b/vendor/plugins/future_articles_sidebar/init.rb
@@ -1,0 +1,5 @@
+require 'sidebar'
+require 'future_articles_sidebar'
+
+FutureArticlesSidebar.view_root = File.dirname(__FILE__) + '/views'
+

--- a/vendor/plugins/future_articles_sidebar/lib/future_articles_sidebar.rb
+++ b/vendor/plugins/future_articles_sidebar/lib/future_articles_sidebar.rb
@@ -1,0 +1,15 @@
+class FutureArticlesSidebar < Sidebar
+  display_name "Future Articles"
+  description "Displays list of unpublished articles."
+
+  setting :title, "Future Articles", :label => "Title"
+  setting :count, 5, :label => "Number of articles"
+
+  def articles
+    @articles ||=
+      Article.find(:all,
+                   :limit => count.to_i,
+                   :conditions => ['published = ? AND published_at > ?', true, Time.now],
+                   :order =>  "published_at ASC" )
+  end
+end

--- a/vendor/plugins/future_articles_sidebar/test/future_articles_sidebar_test.rb
+++ b/vendor/plugins/future_articles_sidebar/test/future_articles_sidebar_test.rb
@@ -1,0 +1,8 @@
+require 'test/unit'
+require File.dirname(__FILE__) + '/../../../../test/test_helper'
+
+class FutureArticlesSidebarTest < Test::Unit::TestCase
+  def test_sidebar_is_available
+    assert Sidebar.available_sidebars.include?(FutureArticlesSidebar)
+  end
+end

--- a/vendor/plugins/future_articles_sidebar/views/content.rhtml
+++ b/vendor/plugins/future_articles_sidebar/views/content.rhtml
@@ -1,0 +1,13 @@
+<% unless sidebar.articles.blank? -%>
+<h3 class='sidebar-title'><%= @sidebar.title %></h3>
+<div>
+    <ol id="future_articles">
+        <% for article in sidebar.articles -%>
+            <li>
+                <p class="future_article_time"><%= time_ago_in_words(article.published_at) %></p>
+                <p class="future_article_title"><%= article.title %></p>
+            </li>
+        <% end %>
+    </ol>
+</div>
+<% end -%>


### PR DESCRIPTION
I've created a tiny sidebar plugin which displays a list future articles (articles written but not yet published). Especially when writing a lot of articles ahead of publishing them, this sidebar plugin is some kind of 'teaser' for upcoming articles.
