### PR TITLE
Added safe_html to three themes

### DIFF
--- a/themes/dirtylicious/views/articles/_article.html.erb
+++ b/themes/dirtylicious/views/articles/_article.html.erb
@@ -33,7 +33,7 @@
   </div>
 
 	<p class="info">
-		<%= content_tag(:span, category_links(article) << ' | ', :class => 'categories') unless article.categories.empty? %>
+		<%= content_tag(:span, category_links(article).html_safe << ' | ', :class => 'categories') unless article.categories.empty? %>
 		<%= comments_link(article) << ' | ' if article.allow_comments? %>
 		<% if controller.controller_name == 'articles' and controller.action_name == 'show' %>
 			<%= content_tag(:span, tag_links(article) << ' | ', :class => 'tags') unless article.tags.empty? %>

--- a/themes/scribbish/views/articles/_article.html.erb
+++ b/themes/scribbish/views/articles/_article.html.erb
@@ -34,8 +34,8 @@
   </div>
 
   <ul class="meta">
-    <%= content_tag(:li, category_links(article), :class => 'categories') unless article.categories.empty? %>
-    <%= content_tag(:li, tag_links(article), :class => 'tags') unless article.tags.empty? %>
+    <%= content_tag(:li, category_links(article).html_safe, :class => 'categories') unless article.categories.empty? %>
+    <%= content_tag(:li, tag_links(article).html_safe, :class => 'tags') unless article.tags.empty? %>
     <li><%= _("Meta") %>
       <%= trackbacks_link(article) << ',' if article.allow_pings? %>
       <%= comments_link(article) << ',' if article.allow_comments? %>

--- a/themes/typographic/views/articles/_article.html.erb
+++ b/themes/typographic/views/articles/_article.html.erb
@@ -31,7 +31,7 @@
   <% if controller.controller_name == "articles" and controller.action_name == "redirect" %>
   <div class="meta">
     <p class="infos"><small>
-      <%= _("This entry was posted on %s", content_tag(:abbr, js_distance_of_time_in_words_to_now(@article.published_at), {:class => 'published', :title => @article.published_at.xmlschema})) %>
+      <%= _("This entry was posted on %s", content_tag(:abbr, js_distance_of_time_in_words_to_now(@article.published_at).html_safe, {:class => 'published', :title => @article.published_at.xmlschema})) %>
       <%= _("and %s", category_links(@article)) unless @article.categories.empty? %>.
       <%= _("You can follow any any response to this entry through the %s", link_to(_("Atom feed"), @auto_discovery_url_atom)) %>.
       <%= _("You can leave a %s", link_to_permalink(article, _('comment'), 'comments')) unless @article.comments_closed? %>


### PR DESCRIPTION
Typo 6.0.0 on Rails3 showed escaped HTML for tags and categories. I added .safe_html in three themes to fix this.
