### PR TITLE
Missing .html_safe in Scribbish theme

### DIFF
--- a/themes/scribbish/views/articles/_comment_form.html.erb
+++ b/themes/scribbish/views/articles/_comment_form.html.erb
@@ -14,7 +14,7 @@
   <p>
     <label><%= _("Name")%>:<br />
       <%= text_field "comment", "author" %>
-      <small>(<%= link_to_function(_("leave url/email") + " &#187;", "Effect.toggle('extra_fields', 'blind', {duration: .3})") %>)</small>
+      <small>(<%= link_to_function((_("leave url/email") + " &#187;").html_safe, "Effect.toggle('extra_fields', 'blind', {duration: .3})") %>)</small>
     </label>
   </p>
 


### PR DESCRIPTION
In the _comment_form partial view, there was a &187 HTML entity coming through in the Scribbish theme (just after 'leave url/email'). 
