### PR TITLE
typo when using filemanager. What if post has no body

### DIFF
--- a/app/views/admin/dashboard/_posts.html.erb
+++ b/app/views/admin/dashboard/_posts.html.erb
@@ -14,7 +14,7 @@
                     link_to_permalink(post, post.title), 
                     post.published_at.strftime(this_blog.date_format),
                     post.published_at.strftime(this_blog.time_format)) %></h4>
-            <p><%= post.body.strip_html.slice(0,300) %></p>            
+            <p><%= post.body.strip_html.slice(0,300) if post.body %></p>            
           </li>
         <% end %>
       <% end %>

--- a/vendor/plugins/filemanager/app/views/fm/filemanager/index.html.erb
+++ b/vendor/plugins/filemanager/app/views/fm/filemanager/index.html.erb
@@ -2,7 +2,7 @@
 <head>
 <title>Filemanager</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<%= javascript_include_tag 'prototype', 'scriptaculous', 'effetcs', 'builder', 'lightbox', 'prototype_ext', :cache => true %>
+<%= javascript_include_tag 'prototype', 'scriptaculous', 'effects', 'builder', 'lightbox', 'prototype_ext', :cache => true %>
 
 <script src="<%= this_blog.base_url %>/javascripts/prototype.js" type="text/javascript"></script>
 <script src="<%= this_blog.base_url %>/javascript/scriptaculous.js?load=effects,builder" type="text/javascript"></script>


### PR DESCRIPTION
There is a typo in typo! When inserting a picture into a post - filemanager tries to access effetcs.js, changed to effects.js.

Also, I was able to create a situation where a post has no body and admin dashboard threw an error. Just a check to make sure post.body exists before it tries to html_strip it
