### PR TITLE
performance optimizations

### DIFF
--- a/app/controllers/admin/sidebar_controller.rb
+++ b/app/controllers/admin/sidebar_controller.rb
@@ -17,30 +17,29 @@ class Admin::SidebarController < Admin::BaseController
 
   def set_active
     # Get all available plugins
-
-    klass_for = available.inject({}) do |hash, klass|
-      hash.merge({ klass.short_name => klass })
-    end
+    klass_for = Hash[
+      available.map {|klass| [klass.short_name, klass] }
+    ]
 
     # Get all already active plugins
-    activemap = flash_sidebars.inject({}) do |h, sb_id|
-      sb = Sidebar.find(sb_id.to_i)
-      sb ? h.merge(sb.html_id => sb_id) : h
-    end
+    activemap = Hash[
+      flash_sidebars.map {|sb_id|
+        sb = Sidebar.find(sb_id.to_i)
+        sb ? [sb.html_id, sb_id] : nil
+      }.compact
+    ]
 
     # Figure out which plugins are referenced by the params[:active] array and
     # lay them out in a easy accessible sequential array
-    flash[:sidebars] = params[:active].inject([]) do |array, name|
+    flash[:sidebars] = params[:active].map {|name|
       if klass_for.has_key?(name)
         new_sidebar_id = klass_for[name].create.id
         @new_item = Sidebar.find(new_sidebar_id)
-        array << new_sidebar_id
+        new_sidebar_id
       elsif activemap.has_key?(name)
-        array << activemap[name]
-      else
-        array
+        activemap[name]
       end
-    end
+    }.compact
   end
 
   def remove

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -1,11 +1,13 @@
 module SidebarHelper
   def render_sidebars(*sidebars)
     begin
-      (sidebars.blank? ? Sidebar.find(:all, :order => 'active_position ASC') : sidebars).inject('') do |acc, sb|
+      acc = ''
+      (sidebars.blank? ? Sidebar.find(:all, :order => 'active_position ASC') : sidebars).each do |sb|
         @sidebar = sb
         sb.parse_request(content_array, params)
-        acc + render_sidebar(sb)
+        acc << render_sidebar(sb)
       end
+      acc
     rescue
       _("It seems something went wrong. Maybe some of your sidebars are actually missing and you should either reinstall them or remove them manually
         ")

--- a/app/models/blog_sweeper.rb
+++ b/app/models/blog_sweeper.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 class BlogSweeper < ActionController::Caching::Sweeper
   observe Category, Blog, User, Article, Page, Categorization, Comment, Trackback
 

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,4 +1,3 @@
-require 'set'
 require 'uri'
 
 class Content < ActiveRecord::Base
@@ -180,7 +179,7 @@ class Content < ActiveRecord::Base
         list_function << 'published_at_like(search_hash[:published_at])'
       end
 
-      if search_hash[:user_id] && search_hash[:user_id].to_i > 0
+      if search_hash[:user_id].to_i.nonzero?
         list_function << 'user_id(search_hash[:user_id])'
       end
 
@@ -245,7 +244,7 @@ class Content < ActiveRecord::Base
   # Grab the text filter for this object.  It's either the filter specified by
   # self.text_filter_id, or the default specified in the default blog object.
   def text_filter
-    if self[:text_filter_id] && !self[:text_filter_id].zero?
+    if self[:text_filter_id] && self[:text_filter_id].nonzero?
       TextFilter.find(self[:text_filter_id])
     else
       default_text_filter
@@ -345,7 +344,7 @@ class Content < ActiveRecord::Base
     post = html(blog.show_extended_on_rss ? :all : :body)
     post = "<p>This article is password protected. Please <a href='#{permalink_url}'>fill in your password</a> to read it</p>" unless self.class.name == 'Article' and (self.password.nil?  or self.password.empty?)
 
-    post = post + get_rss_description
+    post << get_rss_description
 
     xml.description(post)
   end

--- a/app/models/sidebar.rb
+++ b/app/models/sidebar.rb
@@ -253,9 +253,9 @@ class Sidebar < ActiveRecord::Base
   end
 
   def to_locals_hash
-    fields.inject({ :sidebar => self }) do |hash, field|
-      hash.merge(field.key => config[field.key])
-    end
+    acc = [[:sidebar, self]]
+    fields.each {|field| acc << [field.key, config[field.key]] }
+    Hash[acc]
   end
 
   def lifetime

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -47,8 +47,8 @@ class Theme
   end
 
   def self.find_all
-    installed_themes.inject([]) do |array, path|
-      array << theme_from_path(path)
+    installed_themes.map do |path|
+      theme_from_path(path)
     end
   end
 

--- a/db/migrate/014_move_text_filter_to_text_filter_id.rb
+++ b/db/migrate/014_move_text_filter_to_text_filter_id.rb
@@ -13,7 +13,7 @@ class MoveTextFilterToTextFilterId < ActiveRecord::Migration
 
   def self.up
     STDERR.puts "Converting Article and Page to use text_filter_id instead of text_filter"
-    id_of = BareTextFilter.find(:all).inject({}) {|h, f| h.merge({ h[f.name] => f.id }) }
+    id_of = Hash[ BareTextFilter.find(:all).map {|f| [f.name, f.id] } ]
 
     modify_tables_and_update([:add_column, BareArticle, :text_filter_id, :integer],
                              [:add_column, BarePage,    :text_filter_id, :integer]) do
@@ -28,7 +28,7 @@ class MoveTextFilterToTextFilterId < ActiveRecord::Migration
 
   def self.down
     STDERR.puts "Dropping text_filter_id in favor of text_filter"
-    name_of = BareTextFilter.find(:all).inject({}) {|h, f| h.merge({ h[f.id] => f.name })}
+    name_of = Hash[ BareTextFilter.find(:all).map {|f| [f.id, f.name] } ]
 
     modify_tables_and_update([:add_column, BareArticle, :text_filter, :string],
                              [:add_column, BarePage,    :text_filter, :string]) do

--- a/db/migrate/015_convert_mysql_to_innodb.rb
+++ b/db/migrate/015_convert_mysql_to_innodb.rb
@@ -3,9 +3,8 @@ class ConvertMysqlToInnodb < ActiveRecord::Migration
     config = ActiveRecord::Base.configurations
     begin
       STDERR.puts "Migrating all existing tables to InnoDB"
-      schema = []
-      select_all('SHOW TABLES').inject([]) do |schema, table|
-        schema << "ALTER TABLE #{table.to_a.first.last} ENGINE=InnoDB"
+      schema = select_all('SHOW TABLES').map do |table|
+        "ALTER TABLE #{table.to_a.first.last} ENGINE=InnoDB"
       end
       schema.each { |line| execute line }
     end if config[::Rails.env]['adapter'] == 'mysql' unless $schema_generator

--- a/db/migrate/017_add_comment_user_id.rb
+++ b/db/migrate/017_add_comment_user_id.rb
@@ -8,9 +8,9 @@ class AddCommentUserId < ActiveRecord::Migration
   end
 
   def self.up
-    id_for_address = BareUser.find(:all).inject({}) do |h, u|
-      h.merge({ u.email => u.id })
-    end
+    id_for_address = Hash[
+      BareUser.find(:all).map {|u| [u.email, u.id] }
+    ]
 
     modify_tables_and_update(:add_column, BareComment, :user_id, :integer) do |c|
       c.user_id = id_for_address[c.email]

--- a/db/migrate/081_create_cache_informations.rb
+++ b/db/migrate/081_create_cache_informations.rb
@@ -9,9 +9,7 @@ class CreateCacheInformations < ActiveRecord::Migration
       # Ensure no one is going to wipe his own blog public directory
       # It happened once on a release and was no fun at all
       return if public_path == "#{::Rails.root.to_s}/public"
-      srcs = paths.inject([]) { |o,v|
-        o + Dir.glob(public_path + "/#{v}")
-      }
+      srcs = paths.map { |v| Dir.glob(public_path + "/#{v}") }
       return true if srcs.empty?
       trash = ::Rails.root.to_s + "/tmp/typodel.#{UUIDTools::UUID.random_create}"
       FileUtils.makedirs(trash)

--- a/lib/action_web_service/invocation.rb
+++ b/lib/action_web_service/invocation.rb
@@ -119,7 +119,8 @@ module ActionWebService # :nodoc:
         end
 
         def condition_hash(interceptors, *methods)
-          interceptors.inject({}) {|hash, interceptor| hash.merge(interceptor => methods.flatten.map {|method| method.to_s})}
+          cached_method_names = methods.flatten.map {|method| method.to_s}
+          Hash[ interceptors.map { |interceptor| [interceptor, cached_method_names.dup] } ]
         end
     end
 

--- a/lib/sidebars/consolidated_plugin.rb
+++ b/lib/sidebars/consolidated_plugin.rb
@@ -7,9 +7,9 @@ class Sidebars::ConsolidatedPlugin < Sidebars::Plugin
     end
 
     def default_config
-      fields.inject({ }) do |acc, item|
-        acc.merge(item.key => item.default)
-      end
+      Hash[ 
+        fields.map { |item| [item.key, item.default] }
+      ]
     end
 
     def description

--- a/lib/stateful.rb
+++ b/lib/stateful.rb
@@ -46,6 +46,8 @@ module Stateful
   end
 
   module ClassMethods
+    require 'set'
+
     def has_state(field, options = {})
       options.assert_valid_keys(:valid_states, :handles, :initial_state)
 

--- a/spec/controllers/backend_controller_spec.rb
+++ b/spec/controllers/backend_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'action_web_service/test_invoke'
+require 'set'
 
 User.salt = 'change-me'
 

--- a/vendor/plugins/amazon_sidebar/lib/amazon_sidebar.rb
+++ b/vendor/plugins/amazon_sidebar/lib/amazon_sidebar.rb
@@ -8,9 +8,7 @@ class AmazonSidebar < Sidebar
   attr_accessor :asins
 
   def parse_request(contents, request_params)
-    asin_list = contents.to_a.inject([]) do |acc, item|
-      acc + item.whiteboard[:asins].to_a
-    end
+    asin_list = contents.to_a.map { |acc, item| item.whiteboard[:asins].to_a }.flatten
     self.asins = asin_list.uniq.compact[0,maxlinks.to_i]
   end
 end

--- a/vendor/plugins/tag_sidebar/lib/tag_sidebar.rb
+++ b/vendor/plugins/tag_sidebar/lib/tag_sidebar.rb
@@ -12,10 +12,12 @@ class TagSidebar < Sidebar
     return @sizes if @sizes
     total = @tags.inject(0) {|total, tag| total + tag.article_counter }
     average = total.to_f / @tags.size.to_f
-    @sizes = @tags.inject({}) do |h,tag|
-      size = tag.article_counter.to_f / average
-      h.merge tag => [[2.0/3.0, size].max, 2].min * 100
-    end
+    @sizes = Hash[
+      @tags.map do |tag|
+        size = tag.article_counter.to_f / average
+        [tag, [[2.0/3.0, size].max, 2].min * 100]
+      end
+    ]
   end
 
   def font_multiplier

--- a/vendor/plugins/typo_converter/lib/converters/wp25/post.rb
+++ b/vendor/plugins/typo_converter/lib/converters/wp25/post.rb
@@ -9,21 +9,23 @@ module WP25
              :class_name => 'WP25::TermTaxonomy'
 
     def categories
-      term_taxonomies.inject([]) do |list, taxonomy|
+      list = []
+      term_taxonomies.each do |taxonomy|
         if taxonomy.taxonomy.eql?('category')
           list << taxonomy.term.name
         end
-        list
       end
+      list
     end
 
     def tags
-      term_taxonomies.inject([]) do |list, taxonomy|
+      list = []
+      term_taxonomies.map do |taxonomy|
         if taxonomy.taxonomy.eql?('post_tag')
           list << taxonomy.term.name
         end
-        list
       end
+      list
     end
 
     def comments

--- a/vendor/plugins/upload_progress/test/multipart_progress_testx.rb
+++ b/vendor/plugins/upload_progress/test/multipart_progress_testx.rb
@@ -158,9 +158,9 @@ class MockCGI < CGI
     @env['CONTENT_TYPE'] = "multipart/form-data; boundary=#{BOUNDARY}"
     @env['CONTENT_LENGTH'] = @sio.tell - EOL.size
 
-    @session_options = ActionController::CgiRequest::DEFAULT_SESSION_OPTIONS.inject({}) { |options, pair|
-      options[pair.first.to_s] = pair.last; options
-    }
+    @session_options = Hash[
+      ActionController::CgiRequest::DEFAULT_SESSION_OPTIONS.map { |pair| [pair.first.to_s, pair.last] }
+    ]
     session = CGI::Session.new({}, @session_options.merge({'new_session' => true}))
     @session_id = session.session_id
     @env['COOKIE'] = "_session_id=#{session.session_id}"


### PR DESCRIPTION
- Each iteration of `inject` is relatively costly. Where `inject` is used to build a hash, array, or string, use `map` or `each`.
- Append values to strings or arrays with << instead of creating a new object (+) when possible.
- `Set`: I moved invocations of `require 'set'` to files which use instances of `Set`.
