### PR TITLE
fixes an issue in admin where comments doesn't get set as active

### DIFF
--- a/config/initializers/access_rules.rb
+++ b/config/initializers/access_rules.rb
@@ -62,14 +62,14 @@ AccessControl.map :require => [ :admin, :publisher, :contributor ]  do |map|
   end
 
   map.project_module :content, nil do |project|
-    project.menu    "Content",           { :controller => "admin/content",    :action => "index" }
+    project.menu    "Content",          { :controller => "admin/content",    :action => "index" }
     project.submenu "Articles",         { :controller => "admin/content",    :action => "index" }
-    project.submenu "Comments",         { :controller => "admin/feedback" }
-	  project.submenu "Pages",            { :controller => "admin/pages",      :action => "index" }
-	  project.submenu "Categories",       { :controller => "admin/categories", :action => "new" }
-	  project.submenu "Files",            { :controller => "admin/resources",  :action => "index" }
-	  project.submenu "Tags",             { :controller => "admin/tags",       :action => "index" }
-	  project.submenu "",                      { :controller => "admin/comments", :action => "show" }
+    project.submenu "Comments",         { :controller => "admin/feedback",   :action => "index" }
+    project.submenu "Pages",            { :controller => "admin/pages",      :action => "index" }
+    project.submenu "Categories",       { :controller => "admin/categories", :action => "new" }
+    project.submenu "Files",            { :controller => "admin/resources",  :action => "index" }
+    project.submenu "Tags",             { :controller => "admin/tags",       :action => "index" }
+    project.submenu "",                      { :controller => "admin/comments", :action => "show" }
     project.submenu "",                      { :controller => "admin/comments", :action => "new" }
     project.submenu "",                      { :controller => "admin/comments", :action => "edit" }
     project.submenu "",                      { :controller => "admin/comments", :action => "destroy" }


### PR DESCRIPTION
The comments link stays active even if you are on the feedback index page.  With this addition, when you click on comments you get a black span instead of the active link. 
