### PR TITLE
sqlite3-ruby was renamed to sqlite3; changing that in Gemfile, too.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ else
   raise "You need define an adapter in your database.yml" if adapter == '' || adapter.nil?
   case adapter
   when 'sqlite3'
-    gem 'sqlite3-ruby'
+    gem 'sqlite3'
   when 'postgresql'
     gem 'pg'
   when 'mysql'


### PR DESCRIPTION
> ###### 
> 
> Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
> installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
> dependencies accordingly.
> 
> Thanks from the Ruby sqlite3 team!
> 
> <3 <3 <3 <3
> ###### 
