### PR TITLE
Fix for issue #39

### DIFF
--- a/app/controllers/admin/content_controller.rb
+++ b/app/controllers/admin/content_controller.rb
@@ -165,7 +165,9 @@ class Admin::ContentController < Admin::BaseController
     @article.keywords = Tag.collection_to_string @article.tags
 
     @article.attributes = params[:article]
-    @article.published_at = Time.parse(params[:article][:published_at]).utc rescue nil
+    # TODO: Consider refactoring, because double rescue looks... weird.
+    @article.published_at = DateTime.strptime(params[:article][:published_at], "%B %e, %Y %I:%M %p GMT%z").utc rescue
+                            Time.parse(params[:article][:published_at]).utc rescue nil
 
     if request.post?
       set_article_author

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -269,6 +269,11 @@ describe Admin::ContentController do
       assert_equal Time.utc(2011, 2, 17, 19, 47), new_article.published_at
     end
 
+    it 'should respect "GMT+0000 (UTC)" in :published_at' do
+      post :new, 'article' => base_article(:published_at => 'August 23, 2011 08:40 PM GMT+0000 (UTC)')
+      new_article = Article.last
+      assert_equal Time.utc(2011, 8, 23, 20, 40), new_article.published_at
+    end
 
     it 'should create a filtered article' do
       body = "body via *markdown*"


### PR DESCRIPTION
This fix addresses issue #39: Time.parse apparently hiccups when the timestamp string contains "GMT+0000 (UTC)". Worked around this using fdv's suggestion to use DateTime.strptime.
