### PR TITLE
Option to retitle "Archives"

### DIFF
--- a/vendor/plugins/archives_sidebar/app/views/archives_sidebar/_content.html.erb
+++ b/vendor/plugins/archives_sidebar/app/views/archives_sidebar/_content.html.erb
@@ -1,5 +1,5 @@
 <% unless sidebar.archives.blank? %>
-<h3><%= _("Archives")%></h3>
+<h3 class="sidebar-title"><%= sidebar.title %></h3>
 <ul id="archives">
   <% sidebar.archives.each do |month| %>
     <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>

--- a/vendor/plugins/archives_sidebar/lib/archives_sidebar.rb
+++ b/vendor/plugins/archives_sidebar/lib/archives_sidebar.rb
@@ -1,5 +1,6 @@
 class ArchivesSidebar < Sidebar
   description 'Displays links to monthly archives'
+  setting :title, 'Archives'
   setting :show_count, true, :label => 'Show article counts', :input_type => :checkbox
   setting :count,      10,   :label => 'Number of Months'
 


### PR DESCRIPTION
In case anyone else finds this useful: on my site I wanted to give the Archives sidebar a different title e.g. "Previously" or "Old posts".
