### PR TITLE
Copyedit on language definition

### DIFF
--- a/lang/en_US.rb
+++ b/lang/en_US.rb
@@ -8,7 +8,7 @@ Localization.define('en_US') do |l|
   l.store "he_IL", "Hebrew"
   l.store "it_IT", "Italian"
   l.store "ja_JP", "Japanese"
-  l.store "lt_LT", "Lituanian"
+  l.store "lt_LT", "Lithuanian"
   l.store "nb_NO", "Norwegian"
   l.store "nl_NL", "Nederland"
   l.store "pl_PL", "Polish"


### PR DESCRIPTION
There's a missing "h" in the Lithuanian line. 

Wasn't sure about "Nederland" → "Netherlands" as the former appears to be the Dutch name use.
