### PR TITLE
Copyedit: Congrats heading on setup success

### DIFF
--- a/app/views/shared/_confirm.html.erb
+++ b/app/views/shared/_confirm.html.erb
@@ -1,7 +1,7 @@
 <div class='row'>
   <div class='span6 offset2'>
     <div class='well'>
-      <h2><%= _("Congratulation!") %></h2>
+      <h2><%= _("Congratulations!") %></h2>
       <p><%= _("You have successfully signed up") %></p>
       <p>
         <%= _("<strong>Login:</strong> %s", current_user.login)%>

--- a/lang/da_DK.rb
+++ b/lang/da_DK.rb
@@ -592,7 +592,7 @@ Localization.define("da_DK") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/de_DE.rb
+++ b/lang/de_DE.rb
@@ -592,7 +592,7 @@ Localization.define("de_DE") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  # l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/es_MX.rb
+++ b/lang/es_MX.rb
@@ -594,7 +594,7 @@ Localization.define("es_MX") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/fr_FR.rb
+++ b/lang/fr_FR.rb
@@ -652,7 +652,7 @@ Localization.define("fr_FR") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", "Félicitations !"
+  l.store "Congratulations!", "Félicitations !"
   l.store "You have successfully signed up", "Vous vous êtes inscrit avec succès"
   l.store "<strong>Login:</strong> %s", "<strong>Identifiant&nbsp;:</strong> %s"
   l.store "<strong>Password:</strong> %s", "<strong>Mot de passe&nbsp;:</strong> %s"

--- a/lang/he_IL.rb
+++ b/lang/he_IL.rb
@@ -592,7 +592,7 @@ Localization.define("he_IL") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/it_IT.rb
+++ b/lang/it_IT.rb
@@ -592,7 +592,7 @@ Localization.define("it_IT") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/ja_JP.rb
+++ b/lang/ja_JP.rb
@@ -592,7 +592,7 @@ Localization.define("ja_JP") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/lt_LT.rb
+++ b/lang/lt_LT.rb
@@ -592,7 +592,7 @@ Localization.define("lt_LT") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/nb_NO.rb
+++ b/lang/nb_NO.rb
@@ -681,7 +681,7 @@ Localization.define("nb_NO") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", "Velkommen til din %s bloggoppsett. Bare fyll inn bloggtittel og epostadressen din, så vil Typo ta seg av resten"
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", "Gratulerer!"
+  l.store "Congratulations!", "Gratulerer!"
   l.store "You have successfully signed up", "Du er nå registrert"
   l.store "<strong>Login:</strong> %s", "<strong>Logg inn:</strong> %s"
   l.store "<strong>Password:</strong> %s", "<strong>Passord:</strong> %s"

--- a/lang/nl_NL.rb
+++ b/lang/nl_NL.rb
@@ -589,7 +589,7 @@ Localization.define("nl_NL") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", "Welkom bij je %s blog setup. Vul een titel voor je blog in, en een e-mailadres, en Typo zorgt voor de rest"
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", "Gefeliciteerd!"
+  l.store "Congratulations!", "Gefeliciteerd!"
   l.store "You have successfully signed up", "Je bent succesvol aangemeld"
   l.store "<strong>Login:</strong> %s", "<strong>Inlognaam:</strong> %s"
   l.store "<strong>Password:</strong> %s", "<strong>Wachtwoord:</strong> %s"

--- a/lang/pl_PL.rb
+++ b/lang/pl_PL.rb
@@ -595,7 +595,7 @@ Localization.define("pl_PL") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/ro_RO.rb
+++ b/lang/ro_RO.rb
@@ -592,7 +592,7 @@ Localization.define("ro_RO") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""

--- a/lang/zh_TW.rb
+++ b/lang/zh_TW.rb
@@ -592,7 +592,7 @@ Localization.define("zh_TW") do |l|
   l.store "Welcome to your %s blog setup. Just fill in your blog title and your email, and Typo will take care of everything else", ""
 
   # app/views/shared/_confirm.html.erb
-  l.store "Congratulation!", ""
+  l.store "Congratulations!", ""
   l.store "You have successfully signed up", ""
   l.store "<strong>Login:</strong> %s", ""
   l.store "<strong>Password:</strong> %s", ""


### PR DESCRIPTION
After install, screen says "Congratulation" but should instead be "Congratulations" as the former is the act of expressing the latter as a phrase.
