### PR TITLE
Consistent UI in admin sidebar for Feedback section - #98

### DIFF
--- a/config/initializers/access_rules.rb
+++ b/config/initializers/access_rules.rb
@@ -59,7 +59,7 @@ AccessControl.map :require => [ :admin, :publisher, :contributor ]  do |map|
     project.menu    "Articles",       { :controller => "admin/content", :action => "index" }
     project.submenu "All Articles",   { :controller => "admin/content", :action => "index" }
     project.submenu "New Article",    { :controller => "admin/content", :action => "new" }
-    project.submenu "Comments",       { :controller => "admin/feedback", :action => "index" }
+    project.submenu "Feedback",       { :controller => "admin/feedback", :action => "index" }
     project.submenu "Categories",     { :controller => "admin/categories", :action => "new" }
     project.submenu "Tags",           { :controller => "admin/tags", :action => "index" }
     project.submenu "Article Types",  { :controller => "admin/post_types", :action => "new" }


### PR DESCRIPTION
Since admin "Feedback" page contains comments, pings and trackbacks,
have the sidebar item display same title as page itself. 

Helps provide a consistent UI experience.
