### PR TITLE
Show all articles, including drafts, when using default admin filter

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -105,9 +105,13 @@ class Article < Content
   end
 
   def self.search_with_pagination(search_hash, paginate_hash)
-    state = (search_hash[:state] and ["no_draft", "drafts", "published", "withdrawn", "pending"].include? search_hash[:state]) ? search_hash[:state] : 'no_draft'
+    state = (search_hash[:state] and ["no_draft", "drafts", "published", "withdrawn", "pending"].include? search_hash[:state]) ? search_hash[:state] : nil
 
-    list_function  = ["Article.#{state}"] + function_search_no_draft(search_hash)
+    if state.nil?
+      list_function  = function_search_all_posts(search_hash)
+    elsif
+      list_function  = ["Article.#{state}"] + function_search_all_posts(search_hash)
+    end
 
     if search_hash[:category] && search_hash[:category].to_i > 0
       list_function << 'category(search_hash[:category])'

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -54,7 +54,7 @@ class Content < ActiveRecord::Base
     where('published_at < ?', Time.now).limit(1000).order('created_at DESC')
   end
 
-  # Use only for self.function_search_no_draft method
+  # Use only for self.function_search_all_posts method
   scope :published_at_like, lambda {|date_at| {:conditions => {
     :published_at => (
       if date_at =~ /\d{4}-\d{2}-\d{2}/
@@ -70,7 +70,7 @@ class Content < ActiveRecord::Base
   }
   }
 
-  def self.function_search_no_draft(search_hash)
+  def self.function_search_all_posts(search_hash)
     list_function = []
     search_hash ||= {}
 

--- a/app/views/admin/content/index.html.erb
+++ b/app/views/admin/content/index.html.erb
@@ -21,7 +21,7 @@
    <tr class='noborder'>
       <td>
         <select name="search[state]">
-          <option value='no_draft'><%= _("All articles") %></option>
+          <option value=''><%= _("All articles") %></option>
           <option value='published'><%= _("Published") %></option>
           <option value='pending'><%= _("Publication pending") %></option>
           <option value='drafts'><%= _("Drafts") %></option>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -751,10 +751,11 @@ describe Article do
         Article.search_with_pagination({}, {page: nil, per_page: 1}).should eq([article])
       end
 
-      it "returns no draft article by default" do
+      it "returns both published and draft articles by default" do
         article = FactoryGirl.create(:article, state: 'published')
         draft_article = FactoryGirl.create(:article, state: 'draft')
-        Article.search_with_pagination({}, {page: nil, per_page: 12}).should eq([article])
+        result = Article.search_with_pagination({}, {page: nil, per_page: 12})
+        result.count.should eq 2
       end
 
       it "returns article of search categorie" do

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -59,34 +59,34 @@ describe Content do
     end
   end
 
-  describe "#function_search_no_draft" do
+  describe "#function_search_all_posts" do
     it "returns empty array when nil given" do
-      Content.function_search_no_draft(nil).should be_empty
+      Content.function_search_all_posts(nil).should be_empty
     end
 
     it "returns article that match with searchstring" do
       expected_function = ['searchstring(search_hash[:searchstring])']
-      Content.function_search_no_draft({searchstring: 'something'}).should eq expected_function
+      Content.function_search_all_posts({searchstring: 'something'}).should eq expected_function
     end
 
     it "returns article that match with published_at" do
       expected_function = ['published_at_like(search_hash[:published_at])']
-      Content.function_search_no_draft({published_at: '2012-02'}).should eq expected_function
+      Content.function_search_all_posts({published_at: '2012-02'}).should eq expected_function
     end
 
     it "returns article that match with user_id" do
       expected_function = ['user_id(search_hash[:user_id])']
-      Content.function_search_no_draft({user_id: '1'}).should eq expected_function
+      Content.function_search_all_posts({user_id: '1'}).should eq expected_function
     end
 
     it "returns article that match with not published" do
       expected_function = ['not_published']
-      Content.function_search_no_draft({published: '0'}).should eq expected_function
+      Content.function_search_all_posts({published: '0'}).should eq expected_function
     end
 
     it "returns article that match with published" do
       expected_function = ['published']
-      Content.function_search_no_draft({published: '1'}).should eq expected_function
+      Content.function_search_all_posts({published: '1'}).should eq expected_function
     end
 
   end


### PR DESCRIPTION
For issue #87

Default behaviour when landing on "All Articles" section as well as when using the filter for ALL should include drafts along with the rest of the various publish states.

Can then filter to show just all published, all drafts, etc. as needed.

Updates function name from `function_search_no_draft` to `function_search_all_posts` to match new behaviour.

Hoping it's all up to order with the tests as well.
