### PR TITLE
Fix live_search by outputting the ERB form block

### DIFF
--- a/vendor/plugins/livesearch_sidebar/app/views/livesearch_sidebar/_content.html.erb
+++ b/vendor/plugins/livesearch_sidebar/app/views/livesearch_sidebar/_content.html.erb
@@ -1,7 +1,7 @@
 <h3 class='sidebar-title'>
   <label for="q"><%= sidebar.title %></label>
 </h3>
-<% form_tag({:controller => 'articles',  :action => 'search'}, {:method => 'get', :id => 'sform'}) do %>
+<%= form_tag({:controller => 'articles',  :action => 'search'}, {:method => 'get', :id => 'sform'}) do %>
   <%= text_field_tag :q, '', {:id => "live_search", :size => 15, :autocomplete => "off"} %>
   <%= image_tag "spinner-blue.gif", :id => 'search_spinner', :style => 'display:none;' %>
 <% end %>


### PR DESCRIPTION
The live_search sidebar module is missing the search field.  Looking at
the markup, the surrounding form element is missing as well.  Newer
Rails versions require that blocks in ERB use the "<%=" output delimiter
to output markup generated within the block, but the live_search module
is not using that.
    
Switch to the output-style delimiter for the form_tag block.
