### PR TITLE
Make article dashboard filters send correct search params

### DIFF
--- a/app/views/admin/content/index.html.erb
+++ b/app/views/admin/content/index.html.erb
@@ -28,9 +28,9 @@
           <option value='withdrawn'><%= _("Withdrawn") %></option>
         </select>
       </td>
-      <td><%= select_tag('search_category', options_from_collection_for_select(Category.all, 'id', 'name'), {prompt: _("Select a category")}) %></td>
-      <td><%= select_tag('search_user_id', options_from_collection_for_select(User.all, 'id', 'name'), {prompt: _("Select an author")}) %></td>
-      <td><%= select_tag('search_published_at', options_for_select(Article.find_by_published_at), {prompt: _("Publication date")}) %></td>
+      <td><%= select_tag('search[category]', options_from_collection_for_select(Category.all, 'id', 'name'), {prompt: _("Select a category")}) %></td>
+      <td><%= select_tag('search[user_id]', options_from_collection_for_select(User.all, 'id', 'name'), {prompt: _("Select an author")}) %></td>
+      <td><%= select_tag('search[published_at]', options_for_select(Article.find_by_published_at), {prompt: _("Publication date")}) %></td>
       <td><input type="submit" value='<%= _("Filter") %>' class='btn' />
     </tr>
     <tr>


### PR DESCRIPTION
Noticed that the Category, author and published date filters on Article dashboard were not correctly filtering.

Updates to send as part of search hash instead of GET query as the latter was still showing "all" for each respective filter.

This now matches up with article state (published, draft, etc.) and will restrict listings as expected.
