### PR TITLE
Fix dashboard link to display all of Your Posts

### DIFF
--- a/app/views/admin/dashboard/_welcome.html.erb
+++ b/app/views/admin/dashboard/_welcome.html.erb
@@ -7,7 +7,7 @@
   <p><strong><%= _("Content") %></strong></p>
   <ul>
     <li> <%= sprintf("%s %d", link_to(_("Total posts:"), :controller => 'admin/content'), @statposts) %></li>
-    <li> <%= sprintf("%s %d", link_to(_("Your posts:"), :controller => 'admin/content', :search => "[user_id]=#{current_user.id}"), @statuserposts) %></li>
+    <li> <%= sprintf("%s %d", link_to(_("Your posts:"), :controller => 'admin/content', "search[user_id]" => current_user.id), @statuserposts) %></li>
     <li> <%= sprintf("%s %d", link_to(_("Categories:"), :controller => 'admin/categories'), @categories) %></li>
   </ul>
 


### PR DESCRIPTION
Quick link on dashboard to show all your posts was linking to the following URL:

```
http://localhost:3000/admin/content?search=search[user_id]%3D1
```

"search" is expected to be a hash, not a normal query string key. Link needs instead to send:

```
http://localhost:3000/admin/content?search[user_id]=1
```

Now matches the expected search filter calls also used in "Manage articles" admin section.

Fixes #110
