### PR TITLE
Don't initialize when compiling assets to avoid exception on Heroku

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module TypoBlog
 
     # Filter sensitive parameters from the log file
     config.filter_parameters << :password
+
+    # To avoid exception when deploying on Heroku
+    config.assets.initialize_on_precompile = false
   end
 
   # Load included libraries.


### PR DESCRIPTION
Heroku runs rake assets:precompile when deploying a Rails app.

Heroku needs initialize_on_precompile to be false otherwise it throws an exception during deployment (see http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets), if we add this option, we can remove one task in the https://github.com/fdv/typo/wiki/Installing-on-Heroku page :+1: .
