### PR TITLE
Include tip on how to add single and multi-word tags to posts

### DIFF
--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -115,9 +115,10 @@
       </div>
     </div>
 
-		<h4><%= _("Tags") %></h4>
+    <h4><%= _("Tags") %></h4>
     <div class='class'>
       <%= text_field 'article', 'keywords', {:autocomplete => 'off', :style => 'width: 100%'} %>
+      <span class='help-block'><%=_("Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.") %></span>
     </div>
     <%= auto_complete_field 'article_keywords', { :url => { :action => "auto_complete_for_article_keywords"}, :tokens => ','}%>		
   </div>

--- a/lang/da_DK.rb
+++ b/lang/da_DK.rb
@@ -212,6 +212,8 @@ Localization.define("da_DK") do |l|
   l.store "Allow trackbacks", "Tillad Trackbacks"
   l.store "Password:", "Kodeord"
   l.store "Publish", "Udgiv"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", "Filer"

--- a/lang/de_DE.rb
+++ b/lang/de_DE.rb
@@ -212,6 +212,8 @@ Localization.define("de_DE") do |l|
   l.store "Allow trackbacks", "Trackbacks erlauben"
   l.store "Password:", ""
   l.store "Publish", "Veröffentlichen"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", ""

--- a/lang/es_MX.rb
+++ b/lang/es_MX.rb
@@ -214,6 +214,8 @@ Localization.define("es_MX") do |l|
   l.store "Allow trackbacks", "Se permiten trackbacks"
   l.store "Password:", ""
   l.store "Publish", "Publicar"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", ""

--- a/lang/fr_FR.rb
+++ b/lang/fr_FR.rb
@@ -219,6 +219,7 @@ Localization.define("fr_FR") do |l|
   l.store "now", "maintenant"
   l.store "Publish", "Publier"
   l.store "Tags", "Labels"
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", "Extrait"
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", "Les résumés vous permettent d'afficher un texte descriptif de votre article à la place de ce dernier sur la page d'accueil de votre blog"
   l.store "Uploads", "Pièces jointes"

--- a/lang/he_IL.rb
+++ b/lang/he_IL.rb
@@ -212,6 +212,8 @@ Localization.define("he_IL") do |l|
   l.store "Allow trackbacks", "אפשר עוקבים חזרה"
   l.store "Password:", ""
   l.store "Publish", "פרסם"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", "העלאות"

--- a/lang/it_IT.rb
+++ b/lang/it_IT.rb
@@ -212,6 +212,8 @@ Localization.define("it_IT") do |l|
   l.store "Allow trackbacks", "Permetti trackbacks"
   l.store "Password:", ""
   l.store "Publish", "Pubblica"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", "Uploads"

--- a/lang/ja_JP.rb
+++ b/lang/ja_JP.rb
@@ -212,6 +212,8 @@ Localization.define("ja_JP") do |l|
   l.store "Allow trackbacks", "トラックバックを許可"
   l.store "Password:", ""
   l.store "Publish", "公開"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", "要約"
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", "アップロード"

--- a/lang/lt_LT.rb
+++ b/lang/lt_LT.rb
@@ -212,6 +212,8 @@ Localization.define("lt_LT") do |l|
   l.store "Allow trackbacks", "Leisti dienoraščių nuorodas"
   l.store "Password:", ""
   l.store "Publish", "Publikuoti"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", ""

--- a/lang/nb_NO.rb
+++ b/lang/nb_NO.rb
@@ -240,6 +240,7 @@ Localization.define("nb_NO") do |l|
   l.store "Password:", "Passord"
   l.store "Publish", "Publiser"
   l.store "Tags", "Tags"
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", "Utdrag"
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", "Utdrag er oppsummeringer som vises på bloggsiden, men ikke i artikkelen"
   l.store "Uploads", "Opplastede filer"

--- a/lang/nl_NL.rb
+++ b/lang/nl_NL.rb
@@ -210,6 +210,8 @@ Localization.define("nl_NL") do |l|
   l.store "Allow trackbacks", "Sta trackbacks toe"
   l.store "Password:", "Wachtwoord:"
   l.store "Publish", "Publiceer"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", "Uittreksel"
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", "Uittreksels zijn een samenvatting van een post die alleen op de homepage staat, maar niet in de post zelf staan"
   l.store "Uploads", "Uploads"

--- a/lang/pl_PL.rb
+++ b/lang/pl_PL.rb
@@ -215,6 +215,8 @@ Localization.define("pl_PL") do |l|
   l.store "Allow trackbacks", "Zezwól na podawanie trackbacków"
   l.store "Password:", ""
   l.store "Publish", "Publikuj"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", "Załadowane zasoby"

--- a/lang/ro_RO.rb
+++ b/lang/ro_RO.rb
@@ -212,6 +212,8 @@ Localization.define("ro_RO") do |l|
   l.store "Allow trackbacks", "Se permit retrolegături"
   l.store "Password:", ""
   l.store "Publish", "Publică"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", ""
   l.store "Uploads", ""

--- a/lang/zh_CN.rb
+++ b/lang/zh_CN.rb
@@ -213,6 +213,8 @@ Localization.define("zh_CN") do |l|
   l.store "Allow trackbacks", "允许引用"
   l.store "Password:", "密码"
   l.store "Publish", "发布"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", "摘要"
   l.store "Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself", "摘要对文章的总结，只会显示在首页，不会出现在文章正文。"
   l.store "Uploads", "上传"

--- a/lang/zh_TW.rb
+++ b/lang/zh_TW.rb
@@ -212,6 +212,8 @@ Localization.define("zh_TW") do |l|
   l.store "Allow trackbacks", "允許引用"
   l.store "Password:", ""
   l.store "Publish", "公開"
+  l.store "Tags", ""
+  l.store "Separate tags with commas. Use double quotes (&quot;) around multi-word tags, e.g. &quot;opera house&quot;.", ""
   l.store "Excerpt", ""
   l.store "Excerpts are post summaries that show only on your blog homepage but won’t appear on the post itself", ""
   l.store "Uploads", "上載"


### PR DESCRIPTION
Clearly detail how to properly separate multiple tags on a post by the use of commas. Follows convention mentioned in help section of SEO::Titles.

If a user needs to add multi-word tag, then it should also tell them how to do so by use of double quotes. Otherwise they may not expect to see it broken up into individual words as spaces also can separate tags.
