### PR TITLE
Semantic HTML use in Article Resources, punch up message of attached

### DIFF
--- a/app/views/admin/content/_attachment.html.erb
+++ b/app/views/admin/content/_attachment.html.erb
@@ -1,4 +1,4 @@
-<li id="attachment_<%= attachment_num -%>"<% if hidden %> style="display: none;"<% end %>>
+<div id="attachment_<%= attachment_num -%>"<% if hidden %> style="display: none;"<% end %>>
   <%= file_field 'attachments', "filename_#{attachment_num}" -%>
   <%= link_to_function(_("Remove"),
       update_page do |page|
@@ -6,25 +6,33 @@
         page.visual_effect(:toggle_appear, "attachment_#{attachment_num}", :afterFinish => "function(obj){Element.remove(obj.element);}")
         page << "}"
       end) -%>
-</li>
-<li id="attachment_add_<%= attachment_num.succ %>">
+</div>
+<div id="attachment_add_<%= attachment_num.succ %>">
   <%= link_to_remote _('Add another attachment'),
     :url => { :action => "attachment_box_add", :id => attachment_num.succ },
     :asynchronus => false -%>
-</li>
+</div>
 
 <% if @article and @article.id %>
-<li id="resources">
+<div id="resources" class="separator">
+  <h4><%= _("Resources attached to this article")%></h4>
   <% if  @article.resources.count > 0 %>
-    <h3><%= _("Currently this article has the following resources")%></h3>
+    <ul>
     <% for resource in @article.resources %>
-      <%= link_to_remote "- #{resource.upload_url}", :url => { :action => "resource_remove", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %><br/>
+      <li><%= link_to_remote "- #{resource.upload_url}", :url => { :action => "resource_remove", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %></li>
     <% end %>
+    </ul>
+  <% elsif %>
+    <p><%= _("No resources are currently attached")%>.</p>
   <% end %>
 
-  <h3><%= _("You can associate the following resources")%></h3>
-  <% for resource in @resources - @article.resources %>
-    <%= link_to_remote "+ #{resource.upload_url}", :url => { :action => "resource_add", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %><br />
+  <% if @resources.count > 0 %>
+    <h4><%= _("You can associate the following resources")%></h4>
+    <ul>
+    <% for resource in @resources - @article.resources %>
+      <li><%= link_to_remote "+ #{resource.upload_url}", :url => { :action => "resource_add", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %></li>
+    <% end %>
+    </ul>
   <% end %>
-</li>
+</div>
 <% end %>

--- a/app/views/admin/content/_form.html.erb
+++ b/app/views/admin/content/_form.html.erb
@@ -125,20 +125,16 @@
 
   <div class='separator'>
     <h4><%= _("Excerpt") %></h4>
-    <div class=''>
       <%= text_area 'article', 'excerpt', {:height => '150', :style => 'width: 100%', :rows => '5'} %>
       <span class='help-block'><%=_("Excerpts are post summaries that show only on your blog homepage and won’t appear on the post itself") %></span>
-    </div>
   </div>
 
   <div class=''>
     <h4><%= _("Uploads") %></h4>
     <p class='help-block'>Uploads will be displayed as attachments in your RSS feed, but won't appear in your articles.</p>
-    <ul id='attachments' class='inputs-list'>
+    <div id='attachments' class='inputs-list'>
       <%= render 'admin/content/attachment', { :attachment_num => 1, :hidden => false } -%>
-    </ul>
-  </div>    
+    </div>
   </div>
 
 </div>
-

--- a/app/views/admin/content/_show_resources.html.erb
+++ b/app/views/admin/content/_show_resources.html.erb
@@ -1,9 +1,17 @@
-    <h4><%= _("Currently this article has the following resources")%></h4>
-    <% for resource in @article.resources %>
-      <%= link_to_remote "- #{resource.upload_url}", :url => { :action => "resource_remove", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %><br/>
-    <% end %>
+<h4><%= _("Resources attached to this article")%></h4>
+<% if @article.resources.count > 0 %>
+  <ul>
+  <% for resource in @article.resources %>
+    <li><%= link_to_remote "- #{resource.upload_url}", :url => { :action => "resource_remove", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %></li>
+  <% end %>
+  </ul>
+<% elsif %>
+  <p><%= _("No resources are currently attached")%>.</p>
+<% end %>
 
-    <h4><%= _("You can associate the following resources")%></h4>
-    <% for resource in @resources - @article.resources %>
-      <%= link_to_remote "+ #{resource.upload_url}", :url => { :action => "resource_add", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %><br/>
-    <% end %>
+<h4><%= _("You can associate the following resources")%></h4>
+<ul>	
+<% for resource in @resources - @article.resources %>
+  <li><%= link_to_remote "+ #{resource.upload_url}", :url => { :action => "resource_add", :id => @article.id, :resource_id => resource.id}, :update => 'resources' %></li>
+<% end %>
+</ul>

--- a/lang/da_DK.rb
+++ b/lang/da_DK.rb
@@ -198,7 +198,8 @@ Localization.define("da_DK") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Slet"
-  l.store "Currently this article has the following resources", "Artiklen har følgende ressourcer"
+  l.store "Resources attached to this article", "Artiklen har følgende ressourcer"
+  l.store "No resources are currently attached", "Ingen"
   l.store "You can associate the following resources", "Du kan associere den med følgende ressourcer"
   l.store "Really delete attachment", "Vil du virkelig slette vedhæftet fil"
   l.store "Add another attachment", "Vedhæft en fil mere"

--- a/lang/de_DE.rb
+++ b/lang/de_DE.rb
@@ -198,7 +198,8 @@ Localization.define("de_DE") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Löschen"
-  l.store "Currently this article has the following resources", "Aktuell sind folgende Ressourcen dem Artikel zugeordnet"
+  l.store "Resources attached to this article", "Aktuell sind folgende Ressourcen dem Artikel zugeordnet"
+  l.store "No resources are currently attached", "Keiner"
   l.store "You can associate the following resources", "Sie können folgende Ressourcen zuordnen"
   l.store "Really delete attachment", "Anhang wirklich löschen"
   l.store "Add another attachment", "Einen weiteren Anhang hinzufügen"

--- a/lang/es_MX.rb
+++ b/lang/es_MX.rb
@@ -200,7 +200,8 @@ Localization.define("es_MX") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Remover"
-  l.store "Currently this article has the following resources", "Este art&iacute;culo tiene los siguientes recursos"
+  l.store "Resources attached to this article", "Este art&iacute;culo tiene los siguientes recursos"
+  l.store "No resources are currently attached", "Ninguno"
   l.store "You can associate the following resources", "Puedes asociarlo con los siguientes recursos"
   l.store "Really delete attachment", "&iquest;Realmente deseas borrar este archivo?"
   l.store "Add another attachment", "Agregar Otro Archivo"

--- a/lang/fr_FR.rb
+++ b/lang/fr_FR.rb
@@ -196,7 +196,8 @@ Localization.define("fr_FR") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Supprimer"
-  l.store "Currently this article has the following resources", "Les fichiers suivants sont actuellement liés à ce billet"
+  l.store "Resources attached to this article", "Les fichiers suivants sont actuellement liés à ce billet"
+  l.store "No resources are currently attached", "Aucun"
   l.store "You can associate the following resources", "Vous pouvez y lier les fichiers suivants"
   l.store "Really delete attachment", "Voulez-vous vraiment supprimer la pièce jointe"
   l.store "Add another attachment", "Ajouter une autre pièce jointe"

--- a/lang/he_IL.rb
+++ b/lang/he_IL.rb
@@ -198,7 +198,8 @@ Localization.define("he_IL") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "הסר"
-  l.store "Currently this article has the following resources", "כרגע לכתבה שייכים המשאבים הבאים"
+  l.store "Resources attached to this article", "כרגע לכתבה שייכים המשאבים הבאים"
+  l.store "No resources are currently attached", ""
   l.store "You can associate the following resources", "תוכל לשייך אליה את המשאבים הבאים"
   l.store "Really delete attachment", "האם אתה בטוח שברצונך למחוק את הקובץ הצורף"
   l.store "Add another attachment", "הוסף קובץ-מצורף"

--- a/lang/it_IT.rb
+++ b/lang/it_IT.rb
@@ -198,7 +198,8 @@ Localization.define("it_IT") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Elimina"
-  l.store "Currently this article has the following resources", "Questo articolo ha le seguenti risorse"
+  l.store "Resources attached to this article", "Questo articolo ha le seguenti risorse"
+  l.store "No resources are currently attached", "Nessuno"
   l.store "You can associate the following resources", "Puoi associare le seguenti risorse"
   l.store "Really delete attachment", "Vuoi realmente eliminare l'allegato"
   l.store "Add another attachment", "Aggiungi un'altro allegato"

--- a/lang/ja_JP.rb
+++ b/lang/ja_JP.rb
@@ -198,7 +198,8 @@ Localization.define("ja_JP") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "削除"
-  l.store "Currently this article has the following resources", "現在この記事には以下のリソースが含まれています"
+  l.store "Resources attached to this article", "現在この記事には以下のリソースが含まれています"
+  l.store "No resources are currently attached", ""
   l.store "You can associate the following resources", "以下のリソースを整理することができます"
   l.store "Really delete attachment", "本当に添付ファイルを削除してもよろしいですか？"
   l.store "Add another attachment", "添付ファイルを追加"

--- a/lang/lt_LT.rb
+++ b/lang/lt_LT.rb
@@ -198,7 +198,8 @@ Localization.define("lt_LT") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Pašalinti"
-  l.store "Currently this article has the following resources", "Šiuo metu straipsnis turi šiuos resursus"
+  l.store "Resources attached to this article", "Šiuo metu straipsnis turi šiuos resursus"
+  l.store "No resources are currently attached", "Nė vienas"
   l.store "You can associate the following resources", "Jūs galite susieti su šiais resursais"
   l.store "Really delete attachment", "Ištrinti prikabintus failus"
   l.store "Add another attachment", "Prikabinti kitą failą"

--- a/lang/nb_NO.rb
+++ b/lang/nb_NO.rb
@@ -225,7 +225,8 @@ Localization.define("nb_NO") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Slett"
-  l.store "Currently this article has the following resources", "Artiklen har følgende ressourser"
+  l.store "Resources attached to this article", "Artiklen har følgende ressourser"
+  l.store "No resources are currently attached", "Ingen"
   l.store "You can associate the following resources", "Du kan koble til følgende ressourser"
   l.store "Really delete attachment", "Vil du virkelig slette vedlagt fil"
   l.store "Add another attachment", "Vedlegg enda en fil"

--- a/lang/nl_NL.rb
+++ b/lang/nl_NL.rb
@@ -196,7 +196,8 @@ Localization.define("nl_NL") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Verwijder"
-  l.store "Currently this article has the following resources", "Momenteel heeft dit artikel de volgende bronnen"
+  l.store "Resources attached to this article", "Momenteel heeft dit artikel de volgende bronnen"
+  l.store "No resources are currently attached", "Geen"
   l.store "You can associate the following resources", "Je kunt de volgende bronnen koppelen"
   l.store "Really delete attachment", "Bijlage echt verwijderen"
   l.store "Add another attachment", "Voeg een andere bijlage toe"

--- a/lang/pl_PL.rb
+++ b/lang/pl_PL.rb
@@ -201,7 +201,8 @@ Localization.define("pl_PL") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Skasuj"
-  l.store "Currently this article has the following resources", "Artykuł ma dołączone następujące zasoby"
+  l.store "Resources attached to this article", "Artykuł ma dołączone następujące zasoby"
+  l.store "No resources are currently attached", "żaden"
   l.store "You can associate the following resources", "Możesz przypisać do artykułu następujące zasoby"
   l.store "Really delete attachment", "Na pewno skasować?"
   l.store "Add another attachment", "Dodaj kolejny załącznik"

--- a/lang/ro_RO.rb
+++ b/lang/ro_RO.rb
@@ -198,7 +198,8 @@ Localization.define("ro_RO") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "Șterge"
-  l.store "Currently this article has the following resources", "Resursele disponibile acestui articol sînt"
+  l.store "Resources attached to this article", "Resursele disponibile acestui articol sînt"
+  l.store "No resources are currently attached", "Nici una"
   l.store "You can associate the following resources", "Puteți asocia următoarele resurse"
   l.store "Really delete attachment", "Ești sigur că dorești să ștergi atașamentul"
   l.store "Add another attachment", "Adaugă un nou atașament"

--- a/lang/zh_CN.rb
+++ b/lang/zh_CN.rb
@@ -199,7 +199,8 @@ Localization.define("zh_CN") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "移除"
-  l.store "Currently this article has the following resources", "此文章附带了以下资源"
+  l.store "Resources attached to this article", "此文章附带了以下资源"
+  l.store "No resources are currently attached", "无"
   l.store "You can associate the following resources", "你可以联结下列资源"
   l.store "Really delete attachment", "确定删除附件？"
   l.store "Add another attachment", "新增其他附件"

--- a/lang/zh_TW.rb
+++ b/lang/zh_TW.rb
@@ -198,7 +198,8 @@ Localization.define("zh_TW") do |l|
 
   # app/views/admin/content/_attachment.html.erb
   l.store "Remove", "移除"
-  l.store "Currently this article has the following resources", ""
+  l.store "Resources attached to this article", ""
+  l.store "No resources are currently attached", "無"
   l.store "You can associate the following resources", "你可以連結下列資源"
   l.store "Really delete attachment", "確定刪除附件？"
   l.store "Add another attachment", "新增其他附件"


### PR DESCRIPTION
Shortens the "Currently this article has the following resources" heading to something less passive.

Too many uses of UL and LI, removes them and instead only use list markup on the item resources attached to a post.

Adds short message that says there are none currently attached instead of just a blank space that goes straight into the heading and section of available resources to include.

The translations added are just for the word, "None".
