### PR TITLE
Added connection default params like unicode and pool-size

### DIFF
--- a/config/database.yml.pgsql
+++ b/config/database.yml.pgsql
@@ -1,16 +1,26 @@
 login: &login
   adapter: postgresql
   host: localhost
+  port: 5432
   username: postgres
+  password:
+
+connection: &connection
+  encoding: unicode
+  pool: 5
+
 
 development:
   database: typo_dev
   <<: *login
+  <<: *connection
 
 test:
   database: typo_tests
   <<: *login
+  <<: *connection
 
 production:
   database: typo
   <<: *login
+  <<: *connection


### PR DESCRIPTION
The postgresql config was a bit log on configuration. I've added some more params that might speed up things and secure, that multi-lang stuff like russian or japanese won't break.
