### PR TITLE
Add background highlight to currently active theme in admin

### DIFF
--- a/app/views/admin/themes/index.html.erb
+++ b/app/views/admin/themes/index.html.erb
@@ -6,27 +6,27 @@
   <% if i == 0 %>
   <div class='row'>
   <% end %>	
+
   <div class='span6'>
-  <% if j > 1 %>
-  <hr />
-  <% end %>
-  <h4><%= theme.name %></h4>
   <% if theme.path == @active.path -%>
+    <div class='alert container-fluid'>
+    <h3><%= theme.name %> - <%= _("Active theme")%></h3>
     <%= image_tag(url_for(:action => 'preview', :theme => theme.name, :skip_relative_url_root => true)) %>
+    <%= theme.description_html %>
   <% else %>
-    <%= link_to(image_tag(url_for(:action => 'preview', :theme => theme.name, :skip_relative_url_root => true)), :action => 'switchto', :theme => theme.name) %>
-  <% end %>
-  <%= theme.description_html %>
-  <% if theme.path == @active.path -%>
-  <p><em>(<%= _("Active theme")%>)</em></p>
-  <% else -%>
-  <p><%= link_to(_("Chose this theme"), {:action => 'switchto', :theme => theme.name}, :class => 'btn btn-info') %></p>
-  <% end -%>		
+    <div class='container-fluid'>
+    <h4><%= link_to(theme.name, {:action => 'switchto', :theme => theme.name}, :title => _("Use this theme")) %></h4>
+    <%= link_to(image_tag(url_for(:action => 'preview', :theme => theme.name, :skip_relative_url_root => true)), 
+	  {:action => 'switchto', :theme => theme.name}, :title => _("Use this theme")) %>
+    <%= theme.description_html %>
+    <p><%= link_to(_("Use this theme"), {:action => 'switchto', :theme => theme.name}, :class => 'btn btn-info') %></p>
+  <% end -%>
+    </div>
   </div>
 
   <% if i == 1 %>
   </div>
-  <% end%>
+  <% end %>
   <% i = (i == 0) ? 1 : 0%>
   <% j += 1 %>
 <% end %>

--- a/lang/da_DK.rb
+++ b/lang/da_DK.rb
@@ -586,13 +586,9 @@ Localization.define("da_DK") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Aktiv tema"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Vælg et tema"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/de_DE.rb
+++ b/lang/de_DE.rb
@@ -586,13 +586,9 @@ Localization.define("de_DE") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Aktives Motiv"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Motiv auswählen"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/es_MX.rb
+++ b/lang/es_MX.rb
@@ -589,13 +589,9 @@ Localization.define("es_MX") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Tema activo"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Escoge un tema"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/fr_FR.rb
+++ b/lang/fr_FR.rb
@@ -571,11 +571,8 @@ Localization.define("fr_FR") do |l|
 
   # app/views/admin/themes/index.html.erb
   l.store "Active theme", "Thème actif"
-  l.store "Chose this theme", "Choisir ce thème"
   l.store "Choose a theme", "Sélectionnez un thème"
-  l.store "Design", "Personnalisation"
-  l.store "Choose theme", "Choisir un thème"
-  l.store "Customize sidebar", "Greffons"
+  l.store "Use this theme", "Choisir ce thème"
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", "Paramètres du compte"

--- a/lang/he_IL.rb
+++ b/lang/he_IL.rb
@@ -587,13 +587,9 @@ Localization.define("he_IL") do |l|
   l.store "Theme editor", "עורך העיצוב"
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "עיצוב פעיל"
-  l.store "Get more themes", "קבל עיצובים נוספים"
-  l.store "You can download third party themes from officially supported %s ", "תוכל להוריד עיצובים נוספים מהאתר %s"
-  l.store "Typogarden", "Typogarden"
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", "כדי להתקין עיצוב עליך תצטרך להעלות אותא אל ספריית העיצובים שלך (Themes). ברגע שהעיצוב הועלה תוכל לראות בדף זה."
   l.store "Choose a theme", "בחר עיצוב"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/it_IT.rb
+++ b/lang/it_IT.rb
@@ -587,13 +587,9 @@ Localization.define("it_IT") do |l|
   l.store "Theme editor", "Editor dei temi"
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Tema Attivo"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Seleziona un tema"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/ja_JP.rb
+++ b/lang/ja_JP.rb
@@ -586,13 +586,9 @@ Localization.define("ja_JP") do |l|
   l.store "Theme editor", "テーマエディタ"
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "現在のテーマ"
-  l.store "Get more themes", "他のテーマの入手"
-  l.store "You can download third party themes from officially supported %s ", "公式サイト%sからサードパーティのテーマをダウンロードできます。"
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", "テーマをインストールするには、アプリケーションのthemes/ディレクトリに任意のテーマのフォルダをアップロードしてください。そうすればそのテーマをこのページで閲覧することができます。"
   l.store "Choose a theme", "テーマの選択"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/lt_LT.rb
+++ b/lang/lt_LT.rb
@@ -587,13 +587,9 @@ Localization.define("lt_LT") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Aktives Motiv"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Motiv auswählen"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/nb_NO.rb
+++ b/lang/nb_NO.rb
@@ -598,14 +598,9 @@ Localization.define("nb_NO") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Aktivt tema"
-  l.store "Chose this theme", "Velg dette temaet"
-  l.store "Get more themes", "Hent flere temaer"
-  l.store "You can download third party themes from officially supported %s ", "Du kan laste ned tredjepartstemaer fra offisielt støttede %s "
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", "For å installere et tema må du laste opp temakatalogen til themes-katalogen til Typo. Når et tema er lastet opp, vil du se det på denne siden."
   l.store "Choose a theme", "Velg et tema"
+  l.store "Use this theme", "Velg dette temaet"
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", "Kontoinnstillinger"

--- a/lang/nl_NL.rb
+++ b/lang/nl_NL.rb
@@ -582,13 +582,9 @@ Localization.define("nl_NL") do |l|
   l.store "Theme editor", "Thema editor"
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Actieve thema's"
-  l.store "Get more themes", "Haal meer thema's op"
-  l.store "You can download third party themes from officially supported %s ", "Je kunt thema's van derden downloaden van officieel ondersteunde %s "
-  l.store "Typogarden", "Typogarden"
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", "Om een thema te installeren moet je het uploaden in de themes map. Zodra het is geupload zou je het op deze pagina moeten zien."
   l.store "Choose a theme", "Kies een thema"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", "Account instellingen"

--- a/lang/pl_PL.rb
+++ b/lang/pl_PL.rb
@@ -590,13 +590,9 @@ Localization.define("pl_PL") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Temat aktywny"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", ""
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/ro_RO.rb
+++ b/lang/ro_RO.rb
@@ -587,13 +587,9 @@ Localization.define("ro_RO") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "Tema activă"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "Alege o temă"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/zh_CN.rb
+++ b/lang/zh_CN.rb
@@ -594,13 +594,9 @@ Localization.define("zh_CN") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "執行中主題"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "選擇主題"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""

--- a/lang/zh_TW.rb
+++ b/lang/zh_TW.rb
@@ -586,13 +586,9 @@ Localization.define("zh_TW") do |l|
   l.store "Theme editor", ""
 
   # app/views/admin/themes/index.html.erb
-  l.store "Choose theme", ""
   l.store "Active theme", "執行中主題"
-  l.store "Get more themes", ""
-  l.store "You can download third party themes from officially supported %s ", ""
-  l.store "Typogarden", ""
-  l.store "To install a theme you  just need to upload the theme folder into your themes directory. Once a theme is uploaded, you should see it on this page.", ""
   l.store "Choose a theme", "選擇主題"
+  l.store "Use this theme", ""
 
   # app/views/admin/users/_form.html.erb
   l.store "Account settings", ""


### PR DESCRIPTION
The italic text to show what theme is active is too small. This marks out the current theme in use with an alert DIV. 

Tidy up the if-else block uses as the contents are mostly different between inactive choices and the active one.

"Use this theme" sounded more direct and action packed than "Choose this theme" for the button.

This also cleans up some language file definitions orphaned by removal of references to Typogarden and installing themes in commit 82c73cd62c3fc616cb44660d9ac6b4dfbe53ddb9
