### PR TITLE
Add Travis CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ Maintainers
 
 [![](https://codeclimate.com/badge.png)](https://codeclimate.com/github/fdv/typo)
 
+[![Build Status](https://travis-ci.org/fdv/typo.png)](https://travis-ci.org/fdv/typo)
+
 This is a list of Typo maintainers. If you have committed, please add
 your name and contact details to the list.
 


### PR DESCRIPTION
I put this next to the existing CodeClimate badge, but I think it would be better to have at the top of the README (gives people assurance that the project is healthy).
