### PR TITLE
Move Travis and CodeClimate badges to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Typo
 ====
+[![Build Status](https://travis-ci.org/fdv/typo.png)](https://travis-ci.org/fdv/typo)
+[![](https://codeclimate.com/badge.png)](https://codeclimate.com/github/fdv/typo)
 
 ### Table of contents
 
@@ -603,10 +605,6 @@ the following:
 
 Maintainers
 -----------
-
-[![](https://codeclimate.com/badge.png)](https://codeclimate.com/github/fdv/typo)
-
-[![Build Status](https://travis-ci.org/fdv/typo.png)](https://travis-ci.org/fdv/typo)
 
 This is a list of Typo maintainers. If you have committed, please add
 your name and contact details to the list.


### PR DESCRIPTION
The Travis and CodeClimate badges were buried far down the page. I think it's good to have these near the top.
