### PR TITLE
Search plugin doesn't echo form tag and has its width hard-coded.

### DIFF
--- a/vendor/plugins/search_sidebar/app/views/search_sidebar/_content.html.erb
+++ b/vendor/plugins/search_sidebar/app/views/search_sidebar/_content.html.erb
@@ -2,7 +2,7 @@
   <label for="q"><%= sidebar.title %></label>
 </h3>
 <%= form_tag({:controller => 'articles',  :action => 'search'}, {:method => 'get', :id => 'sform'}) do %>
-  <input type="text" id="q" name="q" value="" style="width: <%= sidebar.field_width %>px;" />
+  <input type="text" id="q" name="q" value="" size="15" />
   <input type='submit' value='<%= _("Search") %>' />
 <% end %>
 <br style='clear: right' />

--- a/vendor/plugins/search_sidebar/lib/search_sidebar.rb
+++ b/vendor/plugins/search_sidebar/lib/search_sidebar.rb
@@ -3,5 +3,4 @@ class SearchSidebar < Sidebar
   description "Adds basic search sidebar in your Typo blog"
 
   setting :title, 'Search'
-  setting :field_width, 210, :label => 'Field Width (px)'
 end


### PR DESCRIPTION
The search plugin doesn't echo the form_tag, which was deprecated in Rails 3.0 and unsupported in Rails 3.1. This fixes that.

Also, the width of the search bar is hard-coded, which makes it hard to incorporate into custom themed sidebars. This patch moves away from the hard-coded size to a pixel width that is configurable on the sidebar customization page.
