### PR TITLE
Corrected sprintf format in Norwegian translation for users/index.html.erb

### DIFF
--- a/lang/nb_NO.rb
+++ b/lang/nb_NO.rb
@@ -647,7 +647,7 @@ Localization.define("nb_NO") do |l|
   l.store "New User", "Ny bruker"
   l.store "Comments", "Kommentarer"
   l.store "State", "Tilstand"
-  l.store "%s user", "% bruker"
+  l.store "%s user", "%s bruker"
   l.store "Manage users", ""
 
   # app/views/admin/users/new.html.erb


### PR DESCRIPTION
The page failed with this error: invalid value for Integer(): "aktiv"

By the way, am I stepping on anybody's toes if I suggest some changes to the Norwegian translation? Does anyone have specific responsibility for that?

::tor

(Disclaimer: Not experienced in Ruby, Rails, or Typo. I am however experienced in programming and debugging serverside scripted web pages.)
