### PR TITLE
User creation errors are not displayed on the user signup page

### DIFF
--- a/app/views/accounts/signup.html.erb
+++ b/app/views/accounts/signup.html.erb
@@ -1,3 +1,5 @@
+<%= error_messages_for 'user' %>
+
 <div class='row'>
   <div class='span4 offset4'>
     <div class='well'>


### PR DESCRIPTION
After enabling user registration in the general settings (so third parties can sign up for blog post notifications, etc.), the signup form (app/views/accounts/signup.html.erb) does not display user creation errors such as attempting to create two users with the same email address. The page is simply submitted and nothing seems to happen.

The fix is to add the dynamic_form error messages to the top of the signup form.
