### PR TITLE
Adds config TimeZone setting

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,4 +24,9 @@ Publify::Application.configure do
   end
 
   config.log_level = :debug
+
+  #TimeZone setting
+  config.time_zone = 'UTC'
+  config.active_record.default_timezone = :utc
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,4 +26,9 @@ Publify::Application.configure do
 
   # Enable threaded mode
   # config.threadsafe!
+
+  #TimeZone setting
+  config.time_zone = 'UTC'
+  config.active_record.default_timezone = :utc
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,4 +28,9 @@ Publify::Application.configure do
   # config.active_record.schema_format = :sql
 
   config.active_support.deprecation = :stderr
+
+  #TimeZone setting
+  config.time_zone = 'UTC'
+  config.active_record.default_timezone = :utc
+
 end

--- a/lib/publify_time.rb
+++ b/lib/publify_time.rb
@@ -1,7 +1,7 @@
 class PublifyTime
   def self.delta(year = nil, month = nil, day = nil)
     return nil if year.nil? && month.nil? && day.nil?
-    from = Time.utc(year, month || 1, day || 1)
+    from = Time.zone.local(year, month || 1, day || 1)
     to = from.next_year
     to = from.next_month unless month.blank?
     to = from + 1.day unless day.blank?


### PR DESCRIPTION
not use utc, then change timezone.
sync your local system or country.

i want to use Japan timezone JST.
example

```
config.time_zone = 'Tokyo'
config.active_record.default_timezone = :local 
```
