### PR TITLE
Update Gemfile.heroku with 'twitter' gem dependency

### DIFF
--- a/Gemfile.heroku
+++ b/Gemfile.heroku
@@ -23,6 +23,7 @@ gem 'fog'
 gem 'recaptcha', :require => 'recaptcha/rails', :branch => 'rails3'
 gem 'carrierwave'
 gem 'akismet', '~> 1.0'
+gem 'twitter'
 
 gem 'prototype-rails', '~> 3.2.1'
 gem 'prototype_legacy_helper', '0.0.0', :git => 'http://github.com/rails/prototype_legacy_helper.git'


### PR DESCRIPTION
In production.rb `config.cache_classes = true`, and when i'm trying to start the app, i have this error: `..../gems/activesupport-3.2.14/lib/active_support/dependencies.rb:317:in 'rescue in depend_on': No such file to load -- twitter (LoadError)`.

If i change true to false it's ok.

After a brief search i found that this is because of 'twitter' gem dependency, which is absent in Gemfile.heroku (which i used)
