### PR TITLE
links with a slash not space

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -11,15 +11,15 @@ class Status < Content
   setting :in_reply_to_status_id,               :string,    ""
   setting :in_reply_to_protected,               :boolean,   false
   setting :in_reply_to_message,                 :string,    ""
-  
+
   belongs_to :user
   validates_presence_of :body
   validates_uniqueness_of :permalink
   attr_accessor :push_to_twitter, :twitter_message
-  
+
   after_create :set_permalink, :shorten_url
 
-  default_scope order("published_at DESC")  
+  default_scope order("published_at DESC")
 
   TWITTER_FTP_URL_LEGTH = 19
   TWITTER_HTTP_URL_LENGTH = 20
@@ -53,29 +53,29 @@ class Status < Content
     return false unless self.push_to_twitter # Then, what are we doing here?!
     return false unless Blog.default.has_twitter_configured?
     return false unless self.user.has_twitter_configured?
-    
+
     twitter = Twitter::Client.new(
       :consumer_key => Blog.default.twitter_consumer_key,
       :consumer_secret => Blog.default.twitter_consumer_secret,
       :oauth_token => self.user.twitter_oauth_token,
       :oauth_token_secret => self.user.twitter_oauth_token_secret
     )
-    
+
     build_twitter_message
-    
+
     begin
       options = {}
-      
+
       if self.in_reply_to_status_id and self.in_reply_to_status_id != ""
         options = {:in_reply_to_status_id => self.in_reply_to_status_id}
         self.in_reply_to_message = twitter.status(self.in_reply_to_status_id).to_json
       end
-      
+
       tweet = twitter.update(self.message, options)
-       self.twitter_id = tweet.attrs[:id_str]      
-      
+       self.twitter_id = tweet.attrs[:id_str]
+
       self.save
-    
+
       self.user.update_twitter_profile_image(tweet.attrs[:user][:profile_image_url])
       return true
     rescue
@@ -102,7 +102,7 @@ class Status < Content
   private
   def calculate_real_length
     message = self.twitter_message
-    
+
     uris = URI.extract(message, ['http', 'https', 'ftp'])
     uris.each do |uri|
       case uri.split(":")[0]
@@ -113,7 +113,7 @@ class Status < Content
       when "ftp"
         payload = "-" * TWITTER_FTP_URL_LEGTH
       end
-      
+
       message = message.gsub(uri, payload)
     end
 
@@ -128,15 +128,15 @@ class Status < Content
       blog = Blog.default
       prefix = (blog.custom_url_shortener) ? blog.custom_url_shortener : blog.base_url
       prefix.sub!(/^https?\:\/\//, '')
-      return " (#{prefix} #{path})"
+      return " (#{prefix}/#{path})"
     end
   end
-  
+
   def build_twitter_message
     self.twitter_message = self.body.strip_html
-    
+
     length = calculate_real_length
-    
+
     if length > 114
       self.twitter_message = "#{self.twitter_message[0..113]}#{build_short_link(length)}"
     else


### PR DESCRIPTION
I noticed links are broken on your Twitter feed, because prefix and path are joind with a space not slash.

Also my emacs conf still highlights trailing whitespace. Old memories ;)
Just jump to: https://github.com/abelards/publify/compare#L0L131

I'm not using it myself, it's for my own Twitter-reading convenience so I must ask: was there any particular reason for this, like Twitter short-URLing your short-URLs (yo dawg) or so?

See you,
