### PR TITLE
adding a SubToMe button for easier following as RSS is had to deal with

### DIFF
--- a/lib/meta_sidebar/app/views/meta_sidebar/_content.html.erb
+++ b/lib/meta_sidebar/app/views/meta_sidebar/_content.html.erb
@@ -1,8 +1,9 @@
 <h3 class='sidebar-title'><%= sidebar.title %></h3>
 <div class='static-body'>
   <ul>
+    <li><input type="button" onclick="(function(){var z=document.createElement('script');z.src='https://www.subtome.com/load.js';document.body.appendChild(z);})()" value="Follow"></li>
     <li><%= link_to(_("RSS Feed"), feed_rss) %></li>
     <li><%= link_to(_("Admin"), :controller => 'admin/dashboard') %></li>
-    <li><a href='http://publify.co'><%= _("Powered by Publify") %></a></li>    
+    <li><a href='http://publify.co'><%= _("Powered by Publify") %></a></li>
   </ul>
 </div>


### PR DESCRIPTION
Adding a [SubToMe](https://www.subtome.com/#/) button. RSS is amazing but is hard to use for non-geeks as it requires them to copy paste URLs which is both complex and counter-intuitive. Also, it does not work on mobile/tablets. SubToMe is just an HTML5-powered button to make that easy and does not "break" the RSS decentralization and beauty!
