### PR TITLE
Admin login is looking for en.yml keys for placeholder text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,14 @@
 en:
-  hello: "Hello world"
+  accounts:
+    login:
+      login: "Login"
+      password: "Password"
+      remember_me: "Remember me"
+      sign_in: "Sign in"
+
+  admin:
+    cache:
+      index:
+        explanations: "To save on resources, Publify generates static files 
+           along with your content. These files are deleted when a new article
+           is created. You can, at any time, delete these files yourself."


### PR DESCRIPTION
English i18n YAML file is missing keys found in the French. As a result, the admin login screen is showing
HTML errors from placeholder text that does not translate.

![publify login showing errors from missing en.yml](https://f.cloud.github.com/assets/743877/1264388/10576392-2c5f-11e3-802d-826bd84eb232.png)
