### PR TITLE
Change storage setting from storage.yml to heroku config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,12 @@ will write the database configuration so you don’t have to do anything.
 ### Storage
 
 You need to setup Amazon s3 storage to be able to upload files on your
-blog. Edit `config/storage.yml`
+blog. Set heroku config vars.
 
-    provider: AWS
-    engine: AWS
-    aws_access_key_id: YOUR_AWS_ACCESS_KEY_ID
-    aws_secret_access_key: YOUR_AWS_SECRET_ACCESS_KEY
-    aws_bucket: YOUR_AWS_BUCKET_NAME
+    $ heroku config:set provider=AWS \
+      aws_access_key_id=YOUR_AWS_ACCESS_KEY_ID \
+      aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY \
+      aws_bucket=YOUR_AWS_BUCKET_NAME
 
 <a name="gemfile"></a>
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,20 +4,17 @@ if Rails.env.in?(%(test cucumber))
     config.enable_processing = false
   end
 else
-  configuration_file = File.join(Rails.root, "config", "storage.yml")
-  configuration = File.exists?(configuration_file) ? YAML.load_file(configuration_file) : {}
-
   CarrierWave.configure do |config|
-    if configuration["provider"] == "AWS"
+    if ENV["provider"] == "AWS"
       config.storage = :fog
 
       config.fog_credentials = {
         :provider               => 'AWS',
-        :aws_access_key_id      => configuration["aws_access_key_id"],
-        :aws_secret_access_key  => configuration["aws_secret_access_key"]
+        :aws_access_key_id      => ENV["aws_access_key_id"],
+        :aws_secret_access_key  => ENV["aws_secret_access_key"]
       }
 
-      config.fog_directory  = configuration["aws_bucket"]
+      config.fog_directory  = ENV["aws_bucket"]
       config.fog_public     = true
       config.fog_attributes = { 'Cache-Control' => 'max-age=315576000' }
     else

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,6 +1,0 @@
-#Storage provider: Local, AWS
-provider: Local
-# engine: AWS
-# aws_access_key_id: YOUR_AWS_ACCESS_KEY_ID
-# aws_secret_access_key: YOUR_AWS_SECRET_ACCESS_KEY
-# aws_bucket: YOUR_AWS_BUCKET_NAME


### PR DESCRIPTION
Hi, there.
Since I want to create my blog by publify on heroku, I modified some files in publify for my heroku app.
But, I notice this changes cause merge conflict when I get new commits from master. I have to resolve conflicts manually at each time. I think it's not smart. 
Then, I think it's one of good way to use [heroku config](https://devcenter.heroku.com/articles/config-vars).

Even if you don't feel good, you could change from storage.yml to storage.yml.example for avoiding conflicts.
