### PR TITLE
Travis build on 2.0 and 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 rvm:
+  - 2.1.1
   - 2.0.0
-  - 1.9.3
 env:
   - DB=sqlite
   - DB=mysql
   - DB=postgresql
-  
+
 before_script:
   - rake db:create db:migrate


### PR DESCRIPTION
The README specifies that Ruby 2.0 or 2.1 should be used, so this commit synchronizes this with the travis build :+1:.
