### PR TITLE
Updates Heroku deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-if ENV["HEROKU"]
-  ruby '2.0.0'
+if ENV["DYNO"] || ENV["STACK"]
+  ruby '2.1.1'
 
   gem "pg"
   gem "thin" # Change this to another web server if you want (ie. unicorn, passenger, puma...)

--- a/README.md
+++ b/README.md
@@ -75,30 +75,18 @@ You need to setup Amazon s3 storage to be able to upload files on your
 blog. Set heroku config vars.
 
 ```yaml
-heroku config:set provider=AWS 
-aws_access_key_id=YOUR_AWS_ACCESS_KEY_ID 
-aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY 
+heroku config:set provider=AWS
+aws_access_key_id=YOUR_AWS_ACCESS_KEY_ID
+aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
 aws_bucket=YOUR_AWS_BUCKET_NAME
 ```
 
 To generate the Gemfile.lock, run:
 ```bash
-HEROKU=true bundle install
+STACK=cedar bundle install
 ```
 
 Remove Gemfile.lock from .gitignore and commit it.
-
-Add the user env Heroku plugin:
-
-```bash
-heroku labs:enable user-env-compile -a your_app_name
-```
-
-Add the HEROKU config variable to your Heroku instance:
-
-```bash
-heroku set:config HEROKU=true
-```
 
 Push the repository to Heroku.
 


### PR DESCRIPTION
Heroku has removed the user-env-compile plugin which we were using to access ENV vars in the Gemfile : https://devcenter.heroku.com/articles/labs-user-env-compile

Fortunately there is still a way to detect that bundle is running on Heroku because Heroku is injecting the stack name (ie "cedar") in the STACK env variable. When launching processes this env variable is not populated but the DYNO env variable is populated with the dyno name. So if one of these env variables is populated we should be running on Heroku.
