### PR TITLE
Update rails to 4.1.7 security patches that can affect our users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ else
   end
 end
 
-gem 'rails', '~> 4.1.1'
+gem 'rails', '~> 4.1.7'
 gem 'htmlentities'
 gem 'bluecloth', '~> 2.1'
 gem 'coderay', '~> 1.1.0'
@@ -83,6 +83,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.1.0'
   gem 'simplecov', :require => false
   gem 'pry-rails'
+  gem 'guard-rspec'
 end
 
 # Install gems from each theme

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -18,6 +18,14 @@ describe Tag, :type => :model do
     expect(tag.display_name).to eq('Monty Python')
   end
 
+  it 'display names with colon can be found by dash joined name' do
+    expect(Tag.where(:name => 'SaintSeya:Hades').first).to be_nil
+    tag = Tag.create(:name => 'SaintSeya:Hades')
+    expect(tag).to be_valid
+    expect(tag.name).to eq('saintseya-hades')
+    expect(tag.display_name).to eq('SaintSeya:Hades')
+  end
+
   it 'articles can be tagged' do
     a = Article.create(:title => 'an article')
     foo = FactoryGirl.create(:tag, :name => 'foo')


### PR DESCRIPTION
Update rails to 4.1.7 : latest version is a security fix that could affect our users in a bad way.

PS: sorry for the spec, shouldn't make it to that commit, but I'm too lazy to remove it.
