### PR TITLE
Handle correctly tags with colon

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,7 +11,7 @@ class Tag < ActiveRecord::Base
     return if article.keywords.nil?
     tags = []
     Tag.transaction do
-      article.keywords.to_s.scan(/((['"]).*?\2|[\.[[:alnum:]]]+)/).collect do |x|
+      article.keywords.to_s.scan(/((['"]).*?\2|[\.:[[:alnum:]]]+)/).collect do |x|
         x.first.tr("\"'", '')
       end.uniq.map do |tagword|
         tagname = tagword.to_url

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -167,6 +167,12 @@ describe Admin::ContentController, :type => :controller do
       assert_equal 2, new_article.tags.size
     end
 
+    it 'should create an article with a uniq Tag instace named lang:FR' do
+      post :create, 'article' => base_article(:keywords => "lang:FR")
+      new_article = Article.last
+      expect(new_article.tags.map {|tag| tag.name}.include?('lang-fr')).to be_truthy
+    end
+
     it "should correctly interpret time zone in :published_at" do
       post :create, 'article' => base_article(:published_at => "February 17, 2011 08:47 PM GMT+0100 (CET)")
       new_article = Article.last

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -101,6 +101,13 @@ describe Tag, :type => :model do
         it { expect(article.tags.first.name).to eq('foo') }
       end
 
+      context "with a simple keyword, but containing a semi-colon" do
+        let(:article) { create(:article, keywords: "lang:fr") }
+        it { expect(article.tags.size).to eq(1) }
+        it { expect(article.tags.first).to be_kind_of(Tag) }
+        it { expect(article.tags.first.name).to eq('lang-fr') }
+      end
+
       context "with two keyword separate by a coma" do
         let(:article) { create(:article, keywords: "foo, bar") }
         it { expect(article.tags.size).to eq(2) }


### PR DESCRIPTION
Handle correctly tags like lang:FR which will become Tag with {name: 'lang-fr'}. It fixes #529
