### PR TITLE
Delete routes to admin controller which don't exist

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
   end
 
   # Admin/XController
-  %w{content comments profiles general pages feedback resources sidebar textfilters themes trackbacks users settings tags redirects seo post_types}.each do |i|
+  %w{content profiles pages feedback resources sidebar textfilters themes users settings tags redirects seo post_types}.each do |i|
     match "/admin/#{i}", to: "admin/#{i}#index", format: false, via: [:get, :post, :put, :delete] # TODO: convert this magic catchers to resources item to close un-needed HTTP method
     match "/admin/#{i}(/:action(/:id))", to: "admin/#{i}", action: nil, id: nil, format: false, via: [:get, :post, :put, :delete] # TODO: convert this magic catchers to resources item to close un-needed HTTP method
   end


### PR DESCRIPTION
These admin controllers don't exist:
- comments
- general
- trackbacks
