### PR TITLE
Updated rails->4.1.8, Fixed articles_controller specs with incorrect published_at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ public/cache/*
 Gemfile.lock
 .rbenv-version
 .ruby-version
+.ruby-gemset
 .bundle/
 .sass-cache/
 /vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ else
   end
 end
 
-gem 'rails', '~> 4.1.7'
+gem 'rails', '~> 4.1.8'
 gem 'htmlentities'
 gem 'bluecloth', '~> 2.1'
 gem 'coderay', '~> 1.1.0'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The demo is reset every 2 hours.
 To install Publify you need the following:
 
 -   Ruby 2.0 or 2.1
--   Ruby On Rails 4.1.7
+-   Ruby On Rails 4.1.8
 -   A database engine, MySQL, PgSQL or SQLite3
 
 1.  Unzip Publify archive

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -363,7 +363,7 @@ describe ArticlesController, "redirecting", :type => :controller do
   describe 'accessing old-style URL with "articles" as the first part' do
     it 'should redirect to article' do
       create(:blog)
-      article = create(:article, :permalink => 'second-blog-article', :published_at => '2004-04-01 02:00:00', :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
+      article = create(:article, :permalink => 'second-blog-article', :published_at => DateTime.new(2004,4,1,2,0,0), :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
       get :redirect, :from => "articles/2004/04/01/second-blog-article"
       assert_response 301
       expect(response).to redirect_to("http://myblog.net/2004/04/01/second-blog-article")
@@ -371,7 +371,7 @@ describe ArticlesController, "redirecting", :type => :controller do
 
     it 'should redirect to article with url_root' do
       b = build_stubbed(:blog, :base_url => "http://test.host/blog")
-      article = create(:article, :permalink => 'second-blog-article', :published_at => '2004-04-01 02:00:00', :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
+      article = create(:article, :permalink => 'second-blog-article', :published_at => DateTime.new(2004,4,1,2,0,0), :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
       get :redirect, :from => "articles/2004/04/01/second-blog-article"
       assert_response 301
       expect(response).to redirect_to("http://test.host/blog/2004/04/01/second-blog-article")
@@ -379,7 +379,7 @@ describe ArticlesController, "redirecting", :type => :controller do
 
     it 'should redirect to article with articles in url_root' do
       b = build_stubbed(:blog, :base_url => "http://test.host/aaa/articles/bbb")
-      article = create(:article, :permalink => 'second-blog-article', :published_at => '2004-04-01 02:00:00', :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
+      article = create(:article, :permalink => 'second-blog-article', :published_at => DateTime.new(2004,4,1,2,0,0), :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00')
       get :redirect, :from => "articles/2004/04/01/second-blog-article"
       assert_response 301
       expect(response).to redirect_to("http://test.host/aaa/articles/bbb/2004/04/01/second-blog-article")
@@ -395,7 +395,7 @@ describe ArticlesController, "redirecting", :type => :controller do
     end
 
     context "with an article" do
-      let!(:article) { create(:article, :permalink => 'second-blog-article', :published_at => '2004-04-01 02:00:00', :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00') }
+      let!(:article) { create(:article, :permalink => 'second-blog-article', :published_at => DateTime.new(2004,4,1,2,0,0), :updated_at => '2004-04-01 02:00:00', :created_at => '2004-04-01 02:00:00') }
 
       context "try redirect to an unknow location" do
         before(:each) { get :redirect, from: "#{article.permalink}/foo/bar" }
@@ -404,6 +404,8 @@ describe ArticlesController, "redirecting", :type => :controller do
 
       describe "accessing legacy URLs" do
         it 'should redirect from default URL format' do
+          expect(article.published_at).to eq('2004-04-01 02:00:00')
+
           get :redirect, :from => "2004/04/01/second-blog-article"
           expect(response).to redirect_to("http://myblog.net/second-blog-article.html")
         end


### PR DESCRIPTION
I've run tests and have surprised when It failed, because on github everything is green.
I have looked up. Article was published at `2004-03-31` and was not found.