### PR TITLE
Removed useless information in admin/tags/new and admin/pages 

### DIFF
--- a/app/views/admin/pages/_pages.html.erb
+++ b/app/views/admin/pages/_pages.html.erb
@@ -12,7 +12,6 @@
     <%= link_to_edit_with_profiles page.title, page %>
     <%= show_actions page %>
   </td>
-  <td><%= page.name%></td>
   <td>
     <%= author_link(page) %><br>
     <small><%= l(page.created_at) %></small>

--- a/app/views/admin/pages/index.html.erb
+++ b/app/views/admin/pages/index.html.erb
@@ -10,7 +10,6 @@
   <thead>
     <tr class='noborder'>
       <th><%= t(".title") %></th>
-      <th><%= t(".permalink")%></th>
       <th><%= t(".author")%></th>
     </tr>
   </thead>

--- a/app/views/admin/tags/new.html.erb
+++ b/app/views/admin/tags/new.html.erb
@@ -26,7 +26,6 @@
         <tr class='noborder'>
           <th><%= t('.display_name') %></th>
           <th><%= t('.name')  %></th>
-          <th><%= t('.articles') %></th>
         </tr>
       </thead>
       <%- if @tags.empty? %>
@@ -43,7 +42,6 @@
           <%= show_tag_actions tag %>
         </td>
         <td><%= tag.name %></td>
-        <td><%= tag.published_articles.count.to_s %></td>
       </tr>
     <% end %>
       <%= display_pagination(@tags, 3)%>


### PR DESCRIPTION
I removed the articles column in adnin/tags/new and the permanent link column in admin/pages. 

Issues: #449 #451 