### PR TITLE
_action methods became preferred to _filter methods in Rails 4.2.

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,8 +1,8 @@
 class AccountsController < ApplicationController
 
-  before_filter :verify_config
-  before_filter :verify_users, only: [:login, :recover_password]
-  before_filter :redirect_if_already_logged_in, only: :login
+  before_action :verify_config
+  before_action :verify_users, only: [:login, :recover_password]
+  before_action :redirect_if_already_logged_in, only: :login
 
   def index
     if User.count.zero?

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,9 +3,9 @@ class Admin::BaseController < ApplicationController
   @@look_for_migrations = true
   layout 'administration'
 
-  before_filter :login_required, :except => [ :login, :signup ]
-  before_filter :look_for_needed_db_updates, :except => [:login, :signup, :update_database, :migrate]
-  before_filter :check_and_generate_secret_token, :except => [:login, :signup, :update_database, :migrate]
+  before_action :login_required, :except => [ :login, :signup ]
+  before_action :look_for_needed_db_updates, :except => [:login, :signup, :update_database, :migrate]
+  before_action :check_and_generate_secret_token, :except => [:login, :signup, :update_database, :migrate]
 
   private
 

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -2,8 +2,8 @@ class Admin::NotesController < Admin::BaseController
   layout "administration"
   cache_sweeper :blog_sweeper
 
-  before_filter :load_existing_notes, only: [:index, :edit]
-  before_filter :find_note, only: [:edit, :update, :show, :destroy]
+  before_action :load_existing_notes, only: [:index, :edit]
+  before_action :find_note, only: [:edit, :update, :show, :destroy]
 
   def index
     @note = Publisher.new(current_user).new_note

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -3,8 +3,8 @@ require 'base64'
 
 class Admin::PagesController < Admin::BaseController
 
-  before_filter :set_images, only: [:new, :edit]
-  before_filter :set_macro, only: [:new, :edit]
+  before_action :set_images, only: [:new, :edit]
+  before_action :set_macro, only: [:new, :edit]
 
   layout :get_layout
   cache_sweeper :blog_sweeper

--- a/app/controllers/admin/seo_controller.rb
+++ b/app/controllers/admin/seo_controller.rb
@@ -1,6 +1,6 @@
 class Admin::SeoController < Admin::BaseController
   cache_sweeper :blog_sweeper
-  before_filter :set_setting, only: [:index, :titles]
+  before_action :set_setting, only: [:index, :titles]
 
   def index
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,8 @@ class ApplicationController < ActionController::Base
   include ::LoginSystem
   protect_from_forgery :only => [:edit, :update, :delete]
 
-  before_filter :reset_local_cache, :fire_triggers, :load_lang, :set_paths
-  after_filter :reset_local_cache
+  before_action :reset_local_cache, :fire_triggers, :load_lang, :set_paths
+  after_action :reset_local_cache
 
   class << self
     unless self.respond_to? :template_root

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,7 @@
 class ArticlesController < ContentController
-  before_filter :login_required, :only => [:preview, :preview_page]
-  before_filter :auto_discovery_feed, :only => [:show, :index]
-  before_filter :verify_config
+  before_action :login_required, :only => [:preview, :preview_page]
+  before_action :auto_discovery_feed, :only => [:show, :index]
+  before_action :verify_config
 
   layout :theme_layout, except: [:comment_preview, :trackback]
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < FeedbackController
-  before_filter :get_article, only: [:create, :preview]
+  before_action :get_article, only: [:create, :preview]
 
   def create
     @comment = @article.with_options(new_comment_defaults) do |art|

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -16,7 +16,7 @@ class ContentController < ApplicationController
   end
 
   include LoginSystem
-  before_filter :setup_themer
+  before_action :setup_themer
   helper :theme
 
   protected

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,7 +1,7 @@
 class FeedbackController < ApplicationController
   helper :theme
 
-  before_filter :get_article, only: [:create]
+  before_action :get_article, only: [:create]
 
   cache_sweeper :blog_sweeper
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -5,7 +5,7 @@ class NotesController < ContentController
   cache_sweeper :blog_sweeper
   caches_page :index, :show, :if => Proc.new {|c| c.request.query_string == '' }
 
-  after_filter :set_blog_infos
+  after_action :set_blog_infos
 
   def index
     @notes = Note.published.page(params[:page]).per(this_blog.limit_article_display)

--- a/app/controllers/setup_controller.rb
+++ b/app/controllers/setup_controller.rb
@@ -1,5 +1,5 @@
 class SetupController < ApplicationController
-  before_filter :check_config, only: 'index'
+  before_action :check_config, only: 'index'
   layout 'accounts'
 
   def index

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,5 +1,5 @@
 class TagsController < ContentController
-  before_filter :auto_discovery_feed, :only => [:show, :index]
+  before_action :auto_discovery_feed, :only => [:show, :index]
   layout :theme_layout
   cache_sweeper :blog_sweeper
 


### PR DESCRIPTION
_action methods became preferred to _filter methods in Rails 4.2, so this is a straightforward replacement.