### PR TITLE
Changed the "edit" action to "update" action

### DIFF
--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -3,6 +3,6 @@
 <h2 class="page-title"><%= t(".edit_user") %></h2>
 <%- end %>
 
-<%= form_tag :action=>"edit", :id => @user.id do %>
+<%= form_tag :action=>"update", :id => @user.id do %>
   <%= render :partial => "form" %>
 <% end %>


### PR DESCRIPTION
The action was set to "edit," causing attempts to update/edit users to fail.  Changing to "update" used the "update" method in the users_controller.rb rather than the edit method, resolving the issue.