### PR TITLE
Added AWS Region variable for AWS V4 Auth

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -12,6 +12,7 @@ else
         :provider               => 'AWS',
         :aws_access_key_id      => ENV["aws_access_key_id"],
         :aws_secret_access_key  => ENV["aws_secret_access_key"]
+        :region                 => 'ENV["aws_region"]' # e.g. us-west-1 
       }
 
       config.fog_directory  = ENV["aws_bucket"]


### PR DESCRIPTION
AWS V4 Authentication was requiring the region of the bucket to be defined.  Otherwise using an AWS bucket would not work.  See: https://github.com/fog/fog/issues/3275  See Also: http://stackoverflow.com/questions/27091816/retrieve-buckets-objects-without-knowing-buckets-region-with-aws-s3-rest-api

Added the :region variable, which can be defined as an environment variable, to the code here.