### PR TITLE
Fix admin dropdown menu

### DIFF
--- a/app/assets/javascripts/administration_jquery.js
+++ b/app/assets/javascripts/administration_jquery.js
@@ -5,4 +5,7 @@ $(document).ready(function(){
 
   // DatePickers
   $('.datepicker').datepicker();
+
+  // DropDown
+  $(".dropdown-toggle").dropdown();
 });


### PR DESCRIPTION
The dropdown menus on the admin pages were not dropping. This fixes it. If you can't replicate the problem, feel free to ignore this request. But perhaps it will help others.

publify/publify#604