### PR TITLE
Fix for #598 - Can't delete articles

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,7 +11,7 @@ else
       config.fog_credentials = {
         :provider               => 'AWS',
         :aws_access_key_id      => ENV["aws_access_key_id"],
-        :aws_secret_access_key  => ENV["aws_secret_access_key"]
+        :aws_secret_access_key  => ENV["aws_secret_access_key"],
         :region                 => ENV["aws_region"]
       }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,7 +127,12 @@ Rails.application.routes.draw do
 
     resources :notes, only: [:index, :show, :edit, :create, :update, :destroy], format: false
 
-    resources :pages, only: [:index, :new, :edit, :create, :update, :destroy], format: false
+    resources :pages, only: [:index, :new, :edit, :create, :update, :destroy], format: false do
+      member do
+        get 'destroy'
+        post 'destroy'
+      end
+    end
 
     resources :post_types, only: [:index, :edit, :create, :update, :destroy], format: false
 
@@ -169,7 +174,12 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :tags, only: [:index, :edit, :create, :update, :destroy], format: false
+    resources :tags, only: [:index, :edit, :create, :update, :destroy], format: false do
+      member do
+        get 'destroy'
+        post 'destroy'
+      end
+    end
 
     # TODO: Work out if post is actually used or not.
     get 'textfilters/macro_help(/:id)', to: 'textfilters#macro_help', id: nil, format: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,10 @@ Rails.application.routes.draw do
         get 'get_thumbnails'
         post 'upload'
       end
+      member do
+        get 'destroy'
+        post 'destroy'
+      end
     end
 
     resources :seo, only: [:index], format: false do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,10 @@ Rails.application.routes.draw do
         get 'auto_complete_for_article_keywords'
         post 'autosave'
       end
+      member do
+        get 'destroy'
+        post 'destroy'
+      end
     end
 
     resources :feedback, only: [:index, :edit, :create, :update, :destroy], format: false do

--- a/spec/routing/admin/content_spec.rb
+++ b/spec/routing/admin/content_spec.rb
@@ -5,7 +5,7 @@ describe 'Admin::ContentController routing', type: :routing do
     expect(get: '/admin/content/new').to route_to(controller: 'admin/content',
                                                   action: 'new')
   end
-
+  
   it 'routes #autosave' do
     expect(post: '/admin/content/autosave').to route_to(controller: 'admin/content', action: 'autosave')
   end
@@ -13,5 +13,13 @@ describe 'Admin::ContentController routing', type: :routing do
   it 'routes #auto_complete_for_article_keywords' do
     expect(get: '/admin/content/auto_complete_for_article_keywords').to route_to(controller: 'admin/content',
                                                                                  action: 'auto_complete_for_article_keywords')
+  end
+  
+  it 'routes #destroy' do
+    expect(get: '/admin/content/1/destroy').to route_to(controller: 'admin/content', action: 'destroy', id: '1')
+  end
+  
+  it 'routes #destroy' do
+    expect(post: '/admin/content/1/destroy').to route_to(controller: 'admin/content', action: 'destroy', id: '1')
   end
 end

--- a/spec/routing/admin/pages_spec.rb
+++ b/spec/routing/admin/pages_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Admin::PagesController routing', type: :routing do
+  it 'routes #new' do
+    expect(get: '/admin/pages/new').to route_to(controller: 'admin/pages', action: 'new')
+  end
+  
+  it 'routes #destroy' do
+    expect(get: '/admin/pages/1/destroy').to route_to(controller: 'admin/pages', action: 'destroy', id: '1')
+  end
+  
+  it 'routes #destroy' do
+    expect(post: '/admin/pages/1/destroy').to route_to(controller: 'admin/pages', action: 'destroy', id: '1')
+  end
+end

--- a/spec/routing/admin/resources_spec.rb
+++ b/spec/routing/admin/resources_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe 'Admin::ResourcesController routing', type: :routing do
+  it 'routes #destroy' do
+    expect(get: '/admin/resources/1/destroy').to route_to(controller: 'admin/resources', action: 'destroy', id: '1')
+  end
+  
+  it 'routes #destroy' do
+    expect(post: '/admin/resources/1/destroy').to route_to(controller: 'admin/resources', action: 'destroy', id: '1')
+  end
+end

--- a/spec/routing/admin/tags_spec.rb
+++ b/spec/routing/admin/tags_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Admin::TagsController routing', type: :routing do
+  it 'routes #new' do
+    expect(get: '/admin/tags/new').to route_to(controller: 'articles', action: 'redirect', from: 'admin/tags/new')
+  end
+  
+  it 'routes #destroy' do
+    expect(get: '/admin/tags/1/destroy').to route_to(controller: 'admin/tags', action: 'destroy', id: '1')
+  end
+  
+  it 'routes #destroy' do
+    expect(post: '/admin/tags/1/destroy').to route_to(controller: 'admin/tags', action: 'destroy', id: '1')
+  end
+end


### PR DESCRIPTION
This bug I've uncovered when deployed blog live and tried to create and delete a test post. Was able to create, couldn't delete. :) then found the bug already exists (#598), it also reproes in publify demo site. Some fixes were already proposed, though never merged with master. I've looked at proposed fixes, and think the ones I made would be less risky and a bit more appropriate. I've already deployed fixes in my live instance and they work for posts deletion. there may be similar issues with other entities, but they are out of the scope of this proposed fix.