### PR TITLE
Simplify redirects

### DIFF
--- a/app/controllers/admin/redirects_controller.rb
+++ b/app/controllers/admin/redirects_controller.rb
@@ -2,12 +2,12 @@ class Admin::RedirectsController < Admin::BaseController
   before_action :set_redirect, only: [:edit, :update, :destroy]
 
   def index
-    @redirects = Redirect.where('origin is null').order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
+    @redirects = Redirect.order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
     @redirect = Redirect.new
   end
 
   def edit
-    @redirects = Redirect.where('origin is null').order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
+    @redirects = Redirect.order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
   end
 
   def create

--- a/app/controllers/admin/redirects_controller.rb
+++ b/app/controllers/admin/redirects_controller.rb
@@ -2,12 +2,12 @@ class Admin::RedirectsController < Admin::BaseController
   before_action :set_redirect, only: [:edit, :update, :destroy]
 
   def index
-    @redirects = Redirect.order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
+    @redirects = Redirect.where(content_id: nil).order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
     @redirect = Redirect.new
   end
 
   def edit
-    @redirects = Redirect.order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
+    @redirects = Redirect.where(content_id: nil).order('id desc').page(params[:page]).per(this_blog.admin_display_elements)
   end
 
   def create

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -53,8 +53,8 @@ class Note < Content
   def twitter_message
     base_message = body.strip_html
     if too_long?("#{base_message} (#{short_link})")
-      max_length = 140 - "... (#{redirects.first.to_url})".length - 1
-      "#{truncate(base_message, max_length)}... (#{redirects.first.to_url})"
+      max_length = 140 - "... (#{redirect.to_url})".length - 1
+      "#{truncate(base_message, max_length)}... (#{redirect.to_url})"
     else
       "#{base_message} (#{short_link})"
     end
@@ -114,7 +114,7 @@ class Note < Content
   end
 
   def short_link
-    path = redirects.first.from_path
+    path = redirect.from_path
     prefix.sub!(/^https?\:\/\//, '')
     "#{prefix} #{path}"
   end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -2,9 +2,7 @@ class Redirect < ActiveRecord::Base
   validates :from_path, uniqueness: true
   validates :to_path, presence: true
 
-  has_many :redirections
-
-  has_many :contents, through: :redirections
+  belongs_to :contents
 
   def full_to_path
     path = to_path

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -4,7 +4,7 @@
   <footer>
     <small>
       <%= link_to_permalink(note, display_date_and_time(note.published_at)) %> |
-      <%= link_to note.redirects.first.to_url, note.redirects.first.to_url %> |
+      <%= link_to note.redirect.to_url, note.redirect.to_url %> |
       <%= author_link note %>
       <% unless note.twitter_id.blank? %>
         <%=  " | #{link_to(t(".view_on_twitter"), note.twitter_url, {class: 'u-syndication', rel: 'syndication'})}" %>

--- a/db/migrate/20150807134129_simplify_redirect_relations.rb
+++ b/db/migrate/20150807134129_simplify_redirect_relations.rb
@@ -1,0 +1,38 @@
+class SimplifyRedirectRelations < ActiveRecord::Migration
+  class Redirect < ActiveRecord::Base; end
+  class Redirection < ActiveRecord::Base; end
+
+  def up
+    add_column :redirects, :content_id, :integer
+    Redirect.find_each do |redirect|
+      redirections = Redirection.where(redirect_id: redirect.id)
+      if redirections.count > 1
+        raise "Expected zero or one redirections, found #{redirections.count}"
+      end
+      redirection = redirections.first
+      next unless redirection
+      redirect.content_id = redirection.content_id
+      redirect.save!
+    end
+    remove_column :redirects, :origin
+    drop_table :redirections
+  end
+
+  def down
+    create_table :redirections do |t|
+      t.integer :content_id
+      t.integer :redirect_id
+    end
+
+    add_index :redirections, [:content_id]
+    add_index :redirections, [:redirect_id]
+
+    add_column :redirects, :origin, :string
+
+    Redirect.find_each do |redirect|
+      next unless redirect.content_id
+      Redirection.create(redirect_id: redirect.id, content_id: redirect.content_id)
+    end
+    remove_column :redirects, :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150207131657) do
+ActiveRecord::Schema.define(version: 20150807134129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,8 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.integer "tag_id"
   end
 
-  add_index "articles_tags", ["article_id"], name: "index_articles_tags_on_article_id"
-  add_index "articles_tags", ["tag_id"], name: "index_articles_tags_on_tag_id"
+  add_index "articles_tags", ["article_id"], name: "index_articles_tags_on_article_id", using: :btree
+  add_index "articles_tags", ["tag_id"], name: "index_articles_tags_on_tag_id", using: :btree
 
   create_table "blogs", force: :cascade do |t|
     t.text   "settings"
@@ -54,10 +54,10 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.string   "post_type",      default: "read"
   end
 
-  add_index "contents", ["id", "type"], name: "index_contents_on_id_and_type"
-  add_index "contents", ["published"], name: "index_contents_on_published"
-  add_index "contents", ["text_filter_id"], name: "index_contents_on_text_filter_id"
-  add_index "contents", ["user_id"], name: "index_contents_on_user_id"
+  add_index "contents", ["id", "type"], name: "index_contents_on_id_and_type", using: :btree
+  add_index "contents", ["published"], name: "index_contents_on_published", using: :btree
+  add_index "contents", ["text_filter_id"], name: "index_contents_on_text_filter_id", using: :btree
+  add_index "contents", ["user_id"], name: "index_contents_on_user_id", using: :btree
 
   create_table "feedback", force: :cascade do |t|
     t.string   "type"
@@ -83,16 +83,16 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.string   "user_agent"
   end
 
-  add_index "feedback", ["article_id"], name: "index_feedback_on_article_id"
-  add_index "feedback", ["id", "type"], name: "index_feedback_on_id_and_type"
-  add_index "feedback", ["text_filter_id"], name: "index_feedback_on_text_filter_id"
-  add_index "feedback", ["user_id"], name: "index_feedback_on_user_id"
+  add_index "feedback", ["article_id"], name: "index_feedback_on_article_id", using: :btree
+  add_index "feedback", ["id", "type"], name: "index_feedback_on_id_and_type", using: :btree
+  add_index "feedback", ["text_filter_id"], name: "index_feedback_on_text_filter_id", using: :btree
+  add_index "feedback", ["user_id"], name: "index_feedback_on_user_id", using: :btree
 
   create_table "page_caches", force: :cascade do |t|
     t.string "name"
   end
 
-  add_index "page_caches", ["name"], name: "index_page_caches_on_name"
+  add_index "page_caches", ["name"], name: "index_page_caches_on_name", using: :btree
 
   create_table "pings", force: :cascade do |t|
     t.integer  "article_id"
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.datetime "created_at"
   end
 
-  add_index "pings", ["article_id"], name: "index_pings_on_article_id"
+  add_index "pings", ["article_id"], name: "index_pings_on_article_id", using: :btree
 
   create_table "post_types", force: :cascade do |t|
     t.string "name"
@@ -119,22 +119,14 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.integer "right_id"
   end
 
-  add_index "profiles_rights", ["profile_id"], name: "index_profiles_rights_on_profile_id"
-
-  create_table "redirections", force: :cascade do |t|
-    t.integer "content_id"
-    t.integer "redirect_id"
-  end
-
-  add_index "redirections", ["content_id"], name: "index_redirections_on_content_id"
-  add_index "redirections", ["redirect_id"], name: "index_redirections_on_redirect_id"
+  add_index "profiles_rights", ["profile_id"], name: "index_profiles_rights_on_profile_id", using: :btree
 
   create_table "redirects", force: :cascade do |t|
     t.string   "from_path"
     t.string   "to_path"
-    t.string   "origin"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "content_id"
   end
 
   create_table "resources", force: :cascade do |t|
@@ -154,7 +146,7 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.boolean  "itunes_explicit"
   end
 
-  add_index "resources", ["article_id"], name: "index_resources_on_article_id"
+  add_index "resources", ["article_id"], name: "index_resources_on_article_id", using: :btree
 
   create_table "sidebars", force: :cascade do |t|
     t.integer "active_position"
@@ -163,7 +155,7 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.string  "type"
   end
 
-  add_index "sidebars", ["id", "type"], name: "index_sidebars_on_id_and_type"
+  add_index "sidebars", ["id", "type"], name: "index_sidebars_on_id_and_type", using: :btree
 
   create_table "sitealizer", force: :cascade do |t|
     t.string   "path"
@@ -197,7 +189,7 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.string   "trigger_method"
   end
 
-  add_index "triggers", ["pending_item_id", "pending_item_type"], name: "index_triggers_on_pending_item_id_and_pending_item_type"
+  add_index "triggers", ["pending_item_id", "pending_item_type"], name: "index_triggers_on_pending_item_id_and_pending_item_type", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "login"
@@ -217,8 +209,8 @@ ActiveRecord::Schema.define(version: 20150207131657) do
     t.integer  "resource_id"
   end
 
-  add_index "users", ["profile_id"], name: "index_users_on_profile_id"
-  add_index "users", ["resource_id"], name: "index_users_on_resource_id"
-  add_index "users", ["text_filter_id"], name: "index_users_on_text_filter_id"
+  add_index "users", ["profile_id"], name: "index_users_on_profile_id", using: :btree
+  add_index "users", ["resource_id"], name: "index_users_on_resource_id", using: :btree
+  add_index "users", ["text_filter_id"], name: "index_users_on_text_filter_id", using: :btree
 
 end

--- a/spec/controllers/admin/content_controller_spec.rb
+++ b/spec/controllers/admin/content_controller_spec.rb
@@ -93,7 +93,7 @@ describe Admin::ContentController, type: :controller do
       it { expect(response).to be_success }
       it { expect(response).to render_template('new') }
       it { expect(assigns(:article)).to_not be_nil }
-      it { expect(assigns(:article).redirects).to be_empty }
+      it { expect(assigns(:article).redirect).to be_nil }
     end
 
     describe '#create' do
@@ -132,7 +132,7 @@ describe Admin::ContentController, type: :controller do
         it do
           expect do
             post :create, article: article_params
-          end.to_not change(Redirection, :count) end
+          end.to_not change(Redirect, :count) end
 
         it do
           expect do

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -58,19 +58,19 @@ describe Admin::PagesController, type: :controller do
 
       it 'should create a published page with a redirect' do
         post(:create, 'page' => base_page)
-        expect(assigns(:page).redirects.count).to eq(1)
+        expect(assigns(:page).redirect).not_to be_nil
       end
 
       it 'should create an unpublished page without a redirect' do
         post(:create, 'page' => base_page(state: :unpublished, published: false))
-        expect(assigns(:page).redirects.count).to eq(0)
+        expect(assigns(:page).redirect).to be_nil
       end
 
       it 'should create a page published in the future without a redirect' do
         # TODO: published_at parameter is currently ignored
         skip
         post(:create, 'page' => base_page(published_at: (Time.now + 1.hour).to_s))
-        expect(assigns(:page).redirects.count).to eq(0)
+        expect(assigns(:page).redirect).to be_nil
       end
     end
   end

--- a/spec/controllers/admin/redirects_controller_spec.rb
+++ b/spec/controllers/admin/redirects_controller_spec.rb
@@ -1,15 +1,13 @@
 require 'rails_helper'
 
 describe Admin::RedirectsController, type: :controller do
-  render_views
-
   before do
     FactoryGirl.create(:blog)
     henri = FactoryGirl.create(:user, login: 'henri', profile: FactoryGirl.create(:profile_admin, label: Profile::ADMIN))
     request.session = { user: henri.id }
   end
 
-  describe 'GET #index' do
+  describe '#index' do
     it 'responds successfully with an HTTP 200 status code' do
       get :index
       expect(response).to be_success
@@ -20,9 +18,29 @@ describe Admin::RedirectsController, type: :controller do
       get :index
       expect(response).to render_template('index')
     end
+
+    it 'assigns only redirects that are not linked to content' do
+      create(:article)
+      redirect = create(:redirect)
+      get :index
+      expect(assigns(:redirects)).to match_array [redirect]
+    end
+
+    context 'when rendering the view' do
+      render_views
+
+      it 'renders properly with no redirects present' do
+        expect { get :index }.not_to raise_error
+      end
+
+      it 'renders properly with redirects present' do
+        create :redirect
+        expect { get :index }.not_to raise_error
+      end
+    end
   end
 
-  describe 'create a new redirect' do
+  describe '#create' do
     it 'should create a new redirect and redirect to #index' do
       expect do
         post :create, 'redirect' => { from_path: 'some/place',

--- a/spec/controllers/admin/redirects_controller_spec.rb
+++ b/spec/controllers/admin/redirects_controller_spec.rb
@@ -5,8 +5,6 @@ describe Admin::RedirectsController, type: :controller do
 
   before do
     FactoryGirl.create(:blog)
-    # TODO: Delete after removing fixtures
-    Profile.delete_all
     henri = FactoryGirl.create(:user, login: 'henri', profile: FactoryGirl.create(:profile_admin, label: Profile::ADMIN))
     request.session = { user: henri.id }
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -204,26 +204,26 @@ describe Article, type: :model do
   describe 'Testing redirects' do
     it 'a new published article gets a redirect' do
       a = Article.create(title: 'Some title', body: 'some text', published: true)
-      expect(a.redirects.first).not_to be_nil
-      expect(a.redirects.first.to_path).to eq(a.permalink_url)
+      expect(a.redirect).not_to be_nil
+      expect(a.redirect.to_path).to eq(a.permalink_url)
     end
 
     it 'a new unpublished article should not get a redirect' do
       a = Article.create(title: 'Some title', body: 'some text', published: false)
-      expect(a.redirects.first).to be_nil
+      expect(a.redirect).to be_nil
     end
 
     it 'Changin a published article permalink url should only change the to redirection' do
       a = Article.create(title: 'Some title', body: 'some text', published: true)
-      expect(a.redirects.first).not_to be_nil
-      expect(a.redirects.first.to_path).to eq(a.permalink_url)
-      r = a.redirects.first.from_path
+      expect(a.redirect).not_to be_nil
+      expect(a.redirect.to_path).to eq(a.permalink_url)
+      r = a.redirect.from_path
 
       a.permalink = 'some-new-permalink'
       a.save
-      expect(a.redirects.first).not_to be_nil
-      expect(a.redirects.first.to_path).to eq(a.permalink_url)
-      expect(a.redirects.first.from_path).to eq(r)
+      expect(a.redirect).not_to be_nil
+      expect(a.redirect.to_path).to eq(a.permalink_url)
+      expect(a.redirect.from_path).to eq(r)
     end
   end
 

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -27,7 +27,7 @@ describe Content, type: :model do
       before do
         @content = FactoryGirl.build_stubbed :content,
                                              published: true,
-                                             redirects: [FactoryGirl.build_stubbed(:redirect, from_path: 'foo', to_path: 'bar')]
+                                             redirect: FactoryGirl.build_stubbed(:redirect, from_path: 'foo', to_path: 'bar')
       end
 
       describe 'normally' do

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -7,8 +7,8 @@ describe Note, type: :model do
 
     describe 'validations' do
       it { expect(build(:note)).to be_valid }
-      it { expect(build(:note).redirects).to be_empty }
-      it { expect(create(:note).redirects).to_not be_empty }
+      it { expect(build(:note).redirect).to be_blank }
+      it { expect(create(:note).redirect).to_not be_blank }
       it { expect(build(:note, body: nil)).to be_invalid }
 
       it 'with a nil body, return default error message' do
@@ -40,19 +40,19 @@ describe Note, type: :model do
 
         context 'with a blog that have a custome url shortener' do
           let(:url_shortener) { 'shor.tl' }
-          it { expect(note.short_link).to eq("#{url_shortener} #{note.redirects.first.from_path}") }
+          it { expect(note.short_link).to eq("#{url_shortener} #{note.redirect.from_path}") }
         end
 
         context 'with a blog that have a custome url shortener' do
           let(:url_shortener) { nil }
-          it { expect(note.short_link).to eq("mybaseurl.net #{note.redirects.first.from_path}") }
+          it { expect(note.short_link).to eq("mybaseurl.net #{note.redirect.from_path}") }
         end
       end
     end
 
-    describe 'redirects' do
+    describe '#redirect' do
       let(:note) { create(:note) }
-      it { expect(note.redirects.map(&:to_path)).to eq([note.permalink_url]) }
+      it { expect(note.redirect.to_path).to eq note.permalink_url }
     end
 
     describe 'scopes' do
@@ -146,22 +146,22 @@ describe Note, type: :model do
 
       context 'with a short message much more than 114 char' do
         let(:tweet) { 'A very big(10) message with lot of text (40)inside just to try the shortener and (80)the new link that publify must create and add at the end' }
-        let(:expected_tweet) { "A very big(10) message with lot of text (40)inside just to try the shortener and (80)the new link that publify... (#{note.redirects.first.to_url})" }
+        let(:expected_tweet) { "A very big(10) message with lot of text (40)inside just to try the shortener and (80)the new link that publify... (#{note.redirect.to_url})" }
         it { expect(note.twitter_message).to eq(expected_tweet) }
         it { expect(note.twitter_message.length).to eq(140) }
       end
 
       context 'With a test message from production...' do
         let(:tweet) { "Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo: RT @abailly Ce midi c'est coding dojo à la Cantine #Nantes. Pour s'inscrire si vous voulez c'est ici: http://cantine.atlantic2.org/evenements/coding-dojo-8/ … Sinon venez comme vous êtes" }
-        let(:expected_tweet) { "Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo: RT @abailly Ce midi c'est coding... (#{note.redirects.first.to_url})" }
-        it { expect(note.twitter_message).to eq("Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo: RT @abailly Ce midi c'est coding... (#{note.redirects.first.to_url})") }
+        let(:expected_tweet) { "Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo: RT @abailly Ce midi c'est coding... (#{note.redirect.to_url})" }
+        it { expect(note.twitter_message).to eq("Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo: RT @abailly Ce midi c'est coding... (#{note.redirect.to_url})") }
         it { expect(note.twitter_message).to eq(expected_tweet) }
         it { expect(note.twitter_message.length).to eq(138) }
       end
 
       context 'with a bug message' do
         let(:tweet) { "\"JSFuck is an esoteric and educational programming style based on the atomic parts of JavaScript. It uses only six different characters to write and execute code.\" http://www.jsfuck.com/ " }
-        let(:expected_tweet) { "\"JSFuck is an esoteric and educational programming style based on the atomic parts of JavaScript. It uses only... (#{note.redirects.first.to_url})" }
+        let(:expected_tweet) { "\"JSFuck is an esoteric and educational programming style based on the atomic parts of JavaScript. It uses only... (#{note.redirect.to_url})" }
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
         it { expect(note.twitter_message.length).to eq(140) }
@@ -169,7 +169,7 @@ describe Note, type: :model do
 
       context "don't cut word" do
         let(:tweet) { "Le #mobprogramming c'est un peu comme faire un dojo sur une journée entière (ça permet sûrement de faire des petites journées ;-))" }
-        let(:expected_tweet) { "Le #mobprogramming c'est un peu comme faire un dojo sur une journée entière (ça permet sûrement de faire des... (#{note.redirects.first.to_url})" }
+        let(:expected_tweet) { "Le #mobprogramming c'est un peu comme faire un dojo sur une journée entière (ça permet sûrement de faire des... (#{note.redirect.to_url})" }
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
         it { expect(note.twitter_message.length).to eq(138) }
@@ -177,7 +177,7 @@ describe Note, type: :model do
 
       context 'shortner host is count as an url for twitter' do
         let(:tweet) { 'RT @stephaneducasse http://pharocloud.com is so cool. I love love such idea and I wish them success. Excellent work.' }
-        let(:expected_tweet) { "RT @stephaneducasse http://pharocloud.com is so cool. I love love such idea and I wish them success. Excellent... (#{note.redirects.first.to_url})" }
+        let(:expected_tweet) { "RT @stephaneducasse http://pharocloud.com is so cool. I love love such idea and I wish them success. Excellent... (#{note.redirect.to_url})" }
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
         it { expect(note.twitter_message.length).to eq(140) }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -68,15 +68,15 @@ describe Page, type: :model do
     end
   end
 
-  describe 'redirects' do
+  describe '#redirect' do
     context 'with a simple page' do
       let(:page) { create(:page) }
-      it { expect(page.redirects.first.to_path).to eq(page.permalink_url) }
+      it { expect(page.redirect.to_path).to eq(page.permalink_url) }
     end
 
     context 'with an unpublished page' do
       let(:page) { create(:page, published: false) }
-      it { expect(page.redirects).to be_empty }
+      it { expect(page.redirect).to be_blank }
     end
   end
 end


### PR DESCRIPTION
Changes the relation between redirects and content so that each content has (at most) only one redirect, and each redirect has (at most) only one contents. This makes sense for two reasons:

* The code in Content already enforced only one redirect to exist.
* There is no code assigning additional content to a redirect, nor is there any logical reason to want to do so.

This PR also fixes the feature where content-related redirects are hidden from the redirect editor. This makes sense because we do not want to allow editing the target URL for such redirects.