### PR TITLE
Use rubocop with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
   - DB=postgresql
 before_script:
   - bundle exec rake db:create db:migrate
-
 addons:
   code_climate:
     repo_token: 8850bccc6911d74965627b1fafe753beb368fab00d33de0c7576c6598fc1220e
+script:
+  - bundle exec rubocop


### PR DESCRIPTION
I'm expecting this to fail because of the current state of rubocop before #642 but am unsure of if anything else is needed to run rubocop with travis basing on https://github.com/bbatsov/rubocop/blob/master/.travis.yml. Will create and link to an issue if it works