### PR TITLE
In development links use localhost

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,7 +62,7 @@ module ApplicationHelper
     controller.send(:render_to_string, *args, &block)
   end
 
-  def link_to_permalink(item, title, anchor = nil, style = nil, nofollow = nil, only_path = false)
+  def link_to_permalink(item, title, anchor = nil, style = nil, nofollow = nil, only_path = (Rails.env == 'development'))
     options = {}
     options[:class] = style if style
     options[:rel] = 'nofollow' if nofollow


### PR DESCRIPTION
In development all the links take me to production. Can't try out new code that way, so this makes many but not all of them use 'localhost', at least on my machine.