### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ $ rails server
 
 You can now launch you browser and access 127.0.0.1:3000.
 
+## Install Publify on Nitrous
+
+If you don't want to setup anything on your personal machine, you can quickly create a Publify dev environment in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking Quickstart button below:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Publify via `Run > Start Publify` and access your site via `Preview > 3000`.
+
 ## Install Publify on Heroku
 
 In order to install Publify on Heroku, you’ll need to do some minor tweaks.

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your publify project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Publify via "Run > Start Publify"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+rm -rf ~/code/example
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends imagemagick
+sudo apt-get clean
+
+cd ~/code/publify
+
+# publify requires ruby 2.2.4
+rbenv install 2.2.4
+rbenv global 2.2.4
+
+createdb publify_dev
+createdb publify_tests
+mv ~/code/publify/config/database.yml.postgresql ~/code/publify/config/database.yml
+
+# bundle install
+gem install bundler
+bundle install
+
+sed -i 's|  host: localhost||g' config/database.yml
+sed -i 's|  port: 5432||g' config/database.yml
+sed -i 's|  username: postgres||g' config/database.yml
+sed -i 's|  password:||g' config/database.yml
+
+rake db:setup
+rake db:migrate
+rake db:seed
+rake assets:precompile
+rake db:test:prepare

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "rails",
+  "ports": [3000],
+  "name": "Publify",
+  "description": "A self hosted Web publishing platform on Rails.",
+  "scripts": {
+    "Start Publify": "cd ~/code/publify && rails s -b 0.0.0.0"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.