### PR TITLE
removing a parenthesis that caused the most error

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -7,7 +7,7 @@
 
 <p><%= t('.instruction', :default => "Someone has requested a link to change your password, and you can do this through the link below.") %></p>
 
-<p><%= link_to t('.action', :default => "Change my password"), edit_password_url(@resource, reset_password_token: @token, host: blog.base_url)) %></p>
+<p><%= link_to t('.action', :default => "Change my password"), edit_password_url(@resource, reset_password_token: @token, host: blog.base_url) %></p>
 
 <p><%= t('.instruction_2', :default => "If you didn't request this, please ignore this email.") %></p>
 <p><%= t('.instruction_3', :default => "Your password won't change until you access the link above and create a new one.") %></p>


### PR DESCRIPTION
removing a parenthesis that caused the most error