### PR TITLE
Fixed Admin Sidebar updates on Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Other changes
 
+* Fixed Admin Sidebar updates on Postgres (priit)
 * Update Akismet API calls (drakontia)
 * Remove old Rails patches (mvz)
 * Update dependency on Rails to 4.2.5 (mvz)

--- a/app/controllers/admin/sidebar_controller.rb
+++ b/app/controllers/admin/sidebar_controller.rb
@@ -53,7 +53,7 @@ class Admin::SidebarController < Admin::BaseController
                   else
                     Sidebar.valid.find(sidebar_id)
                   end
-        sidebar.update_attributes(staged_position: staged_index)
+        sidebar.update_attributes(staged_position: staged_index, blog_id: this_blog.id)
       end
     end
 


### PR DESCRIPTION
Sidebar ajax request updates are not working because blog_id is nil and postgres does not allow it. 