### PR TITLE
Fixed sidebar update under subdir deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Other changes
 
+* Fixed sidebar update under subdir deployment (priit)
 * Update Akismet API calls (drakontia)
 * Remove old Rails patches (mvz)
 * Update dependency on Rails to 4.2.5 (mvz)

--- a/app/assets/javascripts/sidebar.js
+++ b/app/assets/javascripts/sidebar.js
@@ -8,7 +8,7 @@ var bind_sortable = function() {
         data: data,
         type: 'POST',
         dataType: 'json',
-        url: '/admin/sidebar/sortable',
+        url: 'sidebar/sortable',
         statusCode: {
           200: function(data, textStatus, jqXHR) {
             $('#sidebar-config').replaceWith(data.html);


### PR DESCRIPTION
When Publify is deployed under subdir such as 'example.com/en/myblog' then ajax request fails with 404, because it made request to nonexistant "/admin/sidebar/sortable" under subdir deployment configuration.