### PR TITLE
Load JavaScript asynchronously only in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Other changes
 
+* Load JavaScript asynchronously only in production (priit)
 * Update Akismet API calls (drakontia)
 * Remove old Rails patches (mvz)
 * Update dependency on Rails to 4.2.5 (mvz)

--- a/app/views/layouts/accounts.html.erb
+++ b/app/views/layouts/accounts.html.erb
@@ -7,7 +7,7 @@
     <%= yield :page_title %>
   </title>
   <meta http-equiv="imagetoolbar" content="no">
-  <%= javascript_include_tag 'publify_admin', async: true %>
+  <%= javascript_include_tag 'publify_admin', async: Rails.env.production? %>
   <%= stylesheet_link_tag "accounts", "bootstrap" %>
 </head>
 <body>

--- a/app/views/layouts/administration.html.erb
+++ b/app/views/layouts/administration.html.erb
@@ -5,7 +5,7 @@
   <title><%= this_blog.blog_name %> – <%= controller.controller_name %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="imagetoolbar" content="no">
-  <%= javascript_include_tag 'publify_admin', async: true %>
+  <%= javascript_include_tag 'publify_admin', async: Rails.env.production? %>
   <%= stylesheet_link_tag 'publify_admin' %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/layouts/editor.html.erb
+++ b/app/views/layouts/editor.html.erb
@@ -5,7 +5,7 @@
   <title><%= this_blog.blog_name %> – <%= controller.controller_name %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="imagetoolbar" content="no">
-  <%= javascript_include_tag 'publify_admin', async: true %>
+  <%= javascript_include_tag 'publify_admin', async: Rails.env.production? %>
   <%= stylesheet_link_tag 'publify_admin' %>
   <style type="text/css">
     #carousel-content .slide { width: <%= this_blog.image_thumb_size %>; }


### PR DESCRIPTION
I had random issues under dev mode because javascript loaded admin js libraries without order, because under development mode js libraries are not bundled into one file. 