### PR TITLE
using AR's IN syntax to avoid ambiguous reference

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < Feedback
   scope :presumed_spam, -> { where(state: 'presumed_spam') }
   scope :presumed_ham, -> { where(state: 'presumed_ham') }
   scope :ham, -> { where(state: 'ham') }
-  scope :unconfirmed, -> { where('state in (?, ?)', 'presumed_spam', 'presumed_ham') }
+  scope :unconfirmed, -> { where(state: ['presumed_spam', 'presumed_ham']) }
   scope :last_published, -> { where(published: true).limit(5).order('created_at DESC') }
 
   def notify_user_via_email(user)

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -21,7 +21,7 @@ class Feedback < ActiveRecord::Base
 
   default_scope { order('created_at DESC') }
 
-  scope :ham, -> { where("state in ('presumed_ham', 'ham')") }
+  scope :ham, -> { where(state: ['presumed_ham', 'ham']) }
   scope :spam, -> { where(state: 'spam') }
   scope :published_since, ->(time) { ham.where('published_at > ?', time) }
   scope :presumed_ham, -> { where(state: 'presumed_ham') }


### PR DESCRIPTION
Got this error on `/admin/feedback?only=ham`:

```
PG::AmbiguousColumn: ERROR:  column reference "state" is ambiguous
LINE 1: ...IN ('Article') AND "contents"."blog_id" = $1 AND (state in (...
                                                             ^
: SELECT COUNT(count_column) FROM (SELECT  1 AS count_column FROM "feedback" INNER JOIN "contents" ON "feedback"."article_id" = "contents"."id" WHERE "contents"."type" IN ('Article') AND "contents"."blog_id" = $1 AND (state in ('presumed_ham', 'ham')) LIMIT 20 OFFSET 0) 
```