### PR TITLE
Portuguese translation

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -5,10 +5,10 @@ pt-BR:
       comments:
         one: 1 comentário
         other: "%{count} comentários"
-        zero: sem comentários
+        zero: nenhum comentário
     comment_form:
       comment: Comentário
-      email_address: Endere&ccedil;o de e-mail
+      email_address: Endereço de e-mail
       your_website: Seu website
     meta:
       published_on_html: Publicado em %{publish_date_and_time} por %{by}, tags %{tags}
@@ -18,13 +18,13 @@ pt-BR:
       trackbacks_are_disabled: Trackbacks foram desabilitados
       trackbacks_for: Trackbacks para
     search:
-      search_results_for: Search results for '%{query}'
+      search_results_for: Buscar resultados para '%{query}'
   comments:
     comment:
       by: por
   layouts:
     default:
-      archives: Archives
+      archives: Arquivos
       statuses: Status
   pagination:
     next: Próxima

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -18,7 +18,7 @@ pt-BR:
       trackbacks_are_disabled: Trackbacks foram desabilitados
       trackbacks_for: Trackbacks para
     search:
-      search_results_for: Buscar resultados para '%{query}'
+      search_results_for: Resultados de busca para '%{query}'
   comments:
     comment:
       by: por

--- a/config/locales/sidebars.pt-BR.yml
+++ b/config/locales/sidebars.pt-BR.yml
@@ -2,18 +2,18 @@
 pt-BR:
   authors_sidebar:
     content:
-      authors: Authors
+      authors: Autores
   notes_sidebar:
     content:
-      view_on_twitter: View on Twitter
+      view_on_twitter: Ver no Twitter
   popular_sidebar:
     content:
-      comments: Comments
-      nothing_to_show_yet: Nothing to show yet
+      comments: Comentários
+      nothing_to_show_yet: Nada a exibir no momento
   xml_sidebar:
     content:
-      articles: Articles
-      comments: Comments
-      syndicate: Syndicate
+      articles: Artigos
+      comments: Comentários
+      syndicate: Sindicato
       tag: Tag
       trackbacks: Trackbacks


### PR DESCRIPTION
Some lines on `config/locales/pt-BR.yml` and `config/locales/sidebar-pt.BR.yml` were missing the translation for portuguese or could be improved.