### PR TITLE
fixes broken mail configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,8 +74,9 @@ module Publify
     begin
       mail_settings = YAML.load(File.read("#{::Rails.root.to_s}/config/mail.yml"))
 
-      ActionMailer::Base.delivery_method = mail_settings['method']
-      ActionMailer::Base.server_settings = mail_settings['settings']
+      %w(delivery_method smtp_settings sendmail_settings file_settings).each do |key|
+        ActionMailer::Base.send "#{key}=", mail_settings[key]
+      end
     rescue
       # Fall back to using sendmail by default
       ActionMailer::Base.delivery_method = :sendmail

--- a/config/mail.yml.example
+++ b/config/mail.yml.example
@@ -1,4 +1,4 @@
-method: :smtp
+delivery_method: :smtp
 settings:
   :address: mail.example.com
   :port:    25
@@ -6,3 +6,5 @@ settings:
 # :authentication:  :login
 # :user_name: bob
 # :password: bobsyouruncle
+sendmail_settings:
+  :location: /usr/bin/sendmail


### PR DESCRIPTION
This pull request includes two patches:
* fixes code to use actual ActiveMailer API
* changed mail.yml.example with syntax corresponding to actual ActiveMailer API

NB: The change in using key from 'method' to  'delivery_method'  should not break settings for existing installation because they are already broken and use default :sendmail settings due fallback on the 'server_settings' assignment exception.