### PR TITLE
Update copyright information and contributor list

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,6 @@
 Copyright (c) 2005 Tobias Luetke
+Copyright (c) 2005-2013 Typo Developers & Contributors
+Copyright (c) 2013-2017 Publify Developers & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -148,31 +148,45 @@ heroku restart
 
 ## Maintainers
 
-This is a list of Publify maintainers. If you have committed, please add
-your name and contact details to the list.
+### Current Maintainers
 
 **Frédéric de Villamil** <frederic@publify.co>
 blog: http://t37.net
-irc: neuro`
 
 **Matijs van Zuijlen**
 blog: http://www.matijs.net/blog/
-irc: matijs
 
 **Thomas Lecavelier**
 blog: http://blog.ookook.fr/
-irc: ook
 
 **Yannick François**
 blog: http://elsif.fr
-irc: yaf
+
+### Previous Maintainers & Notable Contributors
+
+**Cyril Mougel**
+blog: http://blog.shingara.fr
+
+**Davide D'Agostino**
+blog: http://www.lipsiasoft.com
+
+**Piers Cawley**
+blog: http://www.bofh.org.uk/
+
+**Scott Laird**
+
+**Kevin Ballard**
+blog: kevin.sb.org
+
+**Patrick Lenz**
+
+**Seth Hall**
 
 And [many more cool people who’ve one day or another contributed to
 Publify](https://github.com/publify/publify/graphs/contributors).
 
 **Original Author: Tobias Luetke**
 blog: http://blog.leetsoft.com/
-irc: xal
 
 Enjoy,
 The Publify team


### PR DESCRIPTION
For #709 and (part of #714).

I've decided to keep the stuff in the license file short, but list relevant individuals in the README (basically using all the names that were at some point in the MAINTAINERS file).

/cc @fdv, @yaf, @ook, @shingara, @pdcawley, @tobi.