### PR TITLE
Refactor articles index

### DIFF
--- a/db/migrate/20170528093428_move_resources_to_content.publify_core_engine.rb
+++ b/db/migrate/20170528093428_move_resources_to_content.publify_core_engine.rb
@@ -1,0 +1,6 @@
+# This migration comes from publify_core_engine (originally 20170528093024)
+class MoveResourcesToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :resources, :article_id, :content_id
+  end
+end

--- a/db/migrate/20170528120220_move_tags_to_content.publify_core_engine.rb
+++ b/db/migrate/20170528120220_move_tags_to_content.publify_core_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from publify_core_engine (originally 20170528094923)
+class MoveTagsToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :articles_tags, :article_id, :content_id
+    rename_table :articles_tags, :contents_tags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161030121548) do
+ActiveRecord::Schema.define(version: 20170528093428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,7 +118,7 @@ ActiveRecord::Schema.define(version: 20161030121548) do
     t.string   "mime"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "article_id"
+    t.integer  "content_id"
     t.boolean  "itunes_metadata"
     t.string   "itunes_author"
     t.string   "itunes_subtitle"
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 20161030121548) do
     t.string   "itunes_category"
     t.boolean  "itunes_explicit"
     t.integer  "blog_id",         null: false
-    t.index ["article_id"], name: "index_resources_on_article_id", using: :btree
+    t.index ["content_id"], name: "index_resources_on_content_id", using: :btree
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170528093428) do
+ActiveRecord::Schema.define(version: 20170528120220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "articles_tags", id: false, force: :cascade do |t|
-    t.integer "article_id"
-    t.integer "tag_id"
-    t.index ["article_id"], name: "index_articles_tags_on_article_id", using: :btree
-    t.index ["tag_id"], name: "index_articles_tags_on_tag_id", using: :btree
-  end
 
   create_table "blogs", force: :cascade do |t|
     t.text   "settings"
@@ -55,6 +48,13 @@ ActiveRecord::Schema.define(version: 20170528093428) do
     t.index ["published"], name: "index_contents_on_published", using: :btree
     t.index ["text_filter_id"], name: "index_contents_on_text_filter_id", using: :btree
     t.index ["user_id"], name: "index_contents_on_user_id", using: :btree
+  end
+
+  create_table "contents_tags", id: false, force: :cascade do |t|
+    t.integer "content_id"
+    t.integer "tag_id"
+    t.index ["content_id"], name: "index_contents_tags_on_content_id", using: :btree
+    t.index ["tag_id"], name: "index_contents_tags_on_tag_id", using: :btree
   end
 
   create_table "feedback", force: :cascade do |t|

--- a/publify_amazon_sidebar/spec/dummy/db/migrate/20170528164251_move_resources_to_content.publify_core_engine.rb
+++ b/publify_amazon_sidebar/spec/dummy/db/migrate/20170528164251_move_resources_to_content.publify_core_engine.rb
@@ -1,0 +1,6 @@
+# This migration comes from publify_core_engine (originally 20170528093024)
+class MoveResourcesToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :resources, :article_id, :content_id
+  end
+end

--- a/publify_amazon_sidebar/spec/dummy/db/migrate/20170528164439_move_tags_to_content.publify_core_engine.rb
+++ b/publify_amazon_sidebar/spec/dummy/db/migrate/20170528164439_move_tags_to_content.publify_core_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from publify_core_engine (originally 20170528094923)
+class MoveTagsToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :articles_tags, :article_id, :content_id
+    rename_table :articles_tags, :contents_tags
+  end
+end

--- a/publify_amazon_sidebar/spec/dummy/db/schema.rb
+++ b/publify_amazon_sidebar/spec/dummy/db/schema.rb
@@ -10,14 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170528164251) do
-
-  create_table "articles_tags", id: false, force: :cascade do |t|
-    t.integer "article_id"
-    t.integer "tag_id"
-    t.index ["article_id"], name: "index_articles_tags_on_article_id"
-    t.index ["tag_id"], name: "index_articles_tags_on_tag_id"
-  end
+ActiveRecord::Schema.define(version: 20170528164439) do
 
   create_table "blogs", force: :cascade do |t|
     t.text   "settings"
@@ -52,6 +45,13 @@ ActiveRecord::Schema.define(version: 20170528164251) do
     t.index ["published"], name: "index_contents_on_published"
     t.index ["text_filter_id"], name: "index_contents_on_text_filter_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
+  end
+
+  create_table "contents_tags", id: false, force: :cascade do |t|
+    t.integer "content_id"
+    t.integer "tag_id"
+    t.index ["content_id"], name: "index_contents_tags_on_content_id"
+    t.index ["tag_id"], name: "index_contents_tags_on_tag_id"
   end
 
   create_table "feedback", force: :cascade do |t|

--- a/publify_amazon_sidebar/spec/dummy/db/schema.rb
+++ b/publify_amazon_sidebar/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160712061355) do
+ActiveRecord::Schema.define(version: 20170528164251) do
 
   create_table "articles_tags", id: false, force: :cascade do |t|
     t.integer "article_id"
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20160712061355) do
     t.string   "mime"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "article_id"
+    t.integer  "content_id"
     t.boolean  "itunes_metadata"
     t.string   "itunes_author"
     t.string   "itunes_subtitle"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20160712061355) do
     t.string   "itunes_category"
     t.boolean  "itunes_explicit"
     t.integer  "blog_id",         null: false
-    t.index ["article_id"], name: "index_resources_on_article_id"
+    t.index ["content_id"], name: "index_resources_on_content_id"
   end
 
   create_table "sidebars", force: :cascade do |t|

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -16,7 +16,7 @@ class ArticlesController < ContentController
                     else
                       this_blog.contents.published_at(params.values_at(:year, :month, :day))
                     end
-    @articles = articles_base.includes(:user, :resources).
+    @articles = articles_base.includes(:user, :resources, :tags).
       where(type: wanted_types).page(params[:page]).per(limit)
 
     respond_to do |format|

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -19,22 +19,13 @@ class ArticlesController < ContentController
     @articles = articles_base.includes(:user).
       where(conditions).page(params[:page]).per(limit)
 
-    @page_title = this_blog.home_title_template
-    @description = this_blog.home_desc_template
-    if params[:year]
-      @page_title = this_blog.archives_title_template
-      @description = this_blog.archives_desc_template
-    elsif params[:page]
-      @page_title = this_blog.paginated_title_template
-      @description = this_blog.paginated_desc_template
-    end
-    @page_title = @page_title.to_title(@articles, this_blog, params)
-    @description = @description.to_title(@articles, this_blog, params)
-
-    @keywords = this_blog.meta_keywords
-
     respond_to do |format|
-      format.html { render_paginated_index }
+      format.html do
+        set_index_title_and_description(this_blog, params)
+        @keywords = this_blog.meta_keywords
+
+        render_paginated_index
+      end
       format.atom do
         render_articles_feed('atom')
       end
@@ -127,6 +118,20 @@ class ArticlesController < ContentController
   end
 
   private
+
+  def set_index_title_and_description(blog, parameters)
+    @page_title = blog.home_title_template
+    @description = blog.home_desc_template
+    if parameters[:year]
+      @page_title = blog.archives_title_template
+      @description = blog.archives_desc_template
+    elsif parameters[:page]
+      @page_title = blog.paginated_title_template
+      @description = blog.paginated_desc_template
+    end
+    @page_title = @page_title.to_title(@articles, blog, parameters)
+    @description = @description.to_title(@articles, blog, parameters)
+  end
 
   def verify_config
     if !this_blog.configured?

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -8,7 +8,7 @@ class ArticlesController < ContentController
   helper :'admin/base'
 
   def index
-    conditions = this_blog.statuses_in_timeline ? ['type in (?, ?)', 'Article', 'Note'] : ['type = ?', 'Article']
+    wanted_types = this_blog.statuses_in_timeline ? ['Article', 'Note'] : ['Article']
 
     limit = this_blog.per_page(params[:format])
     articles_base = if params[:year].blank?
@@ -17,7 +17,7 @@ class ArticlesController < ContentController
                       this_blog.contents.published_at(params.values_at(:year, :month, :day))
                     end
     @articles = articles_base.includes(:user).
-      where(conditions).page(params[:page]).per(limit)
+      where(type: wanted_types).page(params[:page]).per(limit)
 
     respond_to do |format|
       format.html do

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -16,7 +16,7 @@ class ArticlesController < ContentController
                     else
                       this_blog.contents.published_at(params.values_at(:year, :month, :day))
                     end
-    @articles = articles_base.includes(:user).
+    @articles = articles_base.includes(:user, :resources).
       where(type: wanted_types).page(params[:page]).per(limit)
 
     respond_to do |format|

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -16,7 +16,7 @@ class ArticlesController < ContentController
                     else
                       this_blog.contents.published_at(params.values_at(:year, :month, :day))
                     end
-    @articles = articles_base.includes(:user, :resources, :tags).
+    @articles = articles_base.includes(:user, :resources, :tags, :text_filter).
       where(type: wanted_types).page(params[:page]).per(limit)
 
     respond_to do |format|

--- a/publify_core/app/controllers/tags_controller.rb
+++ b/publify_core/app/controllers/tags_controller.rb
@@ -13,7 +13,7 @@ class TagsController < ContentController
     @tag = Tag.find_by!(name: params[:id])
 
     @articles = @tag.
-      articles.includes(:blog, :user, :tags, :resources, :text_filter).
+      contents.includes(:blog, :user, :tags, :resources, :text_filter).
       published.page(params[:page]).per(10)
 
     respond_to do |format|

--- a/publify_core/app/controllers/xml_controller.rb
+++ b/publify_core/app/controllers/xml_controller.rb
@@ -9,7 +9,7 @@ class XmlController < BaseController
 
     @items += Article.find_already_published(1000)
     @items += Page.find_already_published(1000)
-    @items += Tag.find_all_with_article_counters unless this_blog.unindex_tags
+    @items += Tag.find_all_with_content_counters unless this_blog.unindex_tags
 
     respond_to do |format|
       format.googlesitemap

--- a/publify_core/app/helpers/xml_helper.rb
+++ b/publify_core/app/helpers/xml_helper.rb
@@ -1,7 +1,7 @@
 module XmlHelper
   def collection_lastmod(collection)
-    article_updated = collection.articles.order(updated_at: :desc).first
-    article_published = collection.articles.order(published_at: :desc).first
+    article_updated = collection.contents.order(updated_at: :desc).first
+    article_published = collection.contents.order(published_at: :desc).first
 
     times = []
     times.push article_updated.updated_at if article_updated

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -17,7 +17,6 @@ class Article < Content
   has_many :pings, dependent: :destroy
   has_many :trackbacks, dependent: :destroy
   has_many :feedback
-  has_many :resources, inverse_of: :article, dependent: :nullify
   has_many :triggers, as: :pending_item
   has_many :comments, dependent: :destroy
 

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -20,8 +20,6 @@ class Article < Content
   has_many :triggers, as: :pending_item
   has_many :comments, dependent: :destroy
 
-  has_and_belongs_to_many :tags, join_table: 'articles_tags'
-
   before_create :create_guid
   before_save :set_published_at, :set_permalink
   after_save :post_trigger, :keywords_to_tags, :shorten_url

--- a/publify_core/app/models/content.rb
+++ b/publify_core/app/models/content.rb
@@ -16,6 +16,7 @@ class Content < ActiveRecord::Base
 
   has_many :triggers, as: :pending_item, dependent: :delete_all
   has_many :resources, inverse_of: :content, dependent: :nullify
+  has_and_belongs_to_many :tags
 
   scope :user_id, ->(user_id) { where('user_id = ?', user_id) }
   scope :published, -> { where(published: true, published_at: Time.at(0)..Time.now).order('published_at DESC') }

--- a/publify_core/app/models/content.rb
+++ b/publify_core/app/models/content.rb
@@ -15,6 +15,7 @@ class Content < ActiveRecord::Base
   has_one :redirect, dependent: :destroy, inverse_of: :contents
 
   has_many :triggers, as: :pending_item, dependent: :delete_all
+  has_many :resources, inverse_of: :content, dependent: :nullify
 
   scope :user_id, ->(user_id) { where('user_id = ?', user_id) }
   scope :published, -> { where(published: true, published_at: Time.at(0)..Time.now).order('published_at DESC') }

--- a/publify_core/app/models/resource.rb
+++ b/publify_core/app/models/resource.rb
@@ -3,7 +3,7 @@ require 'carrierwave/orm/activerecord'
 
 class Resource < ActiveRecord::Base
   belongs_to :blog
-  belongs_to :article, optional: true
+  belongs_to :content, optional: true
 
   mount_uploader :upload, ResourceUploader
   validates :upload, presence: true

--- a/publify_core/app/models/tag.rb
+++ b/publify_core/app/models/tag.rb
@@ -1,6 +1,6 @@
 class Tag < ActiveRecord::Base
   belongs_to :blog
-  has_and_belongs_to_many :articles, order: 'created_at DESC', join_table: 'articles_tags'
+  has_and_belongs_to_many :contents, order: 'created_at DESC'
 
   validates :name, uniqueness: { scope: :blog_id }
   validates :blog, presence: true
@@ -33,12 +33,12 @@ class Tag < ActiveRecord::Base
     self.name = display_name.to_url if display_name.present?
   end
 
-  def self.find_all_with_article_counters
-    Tag.joins(:articles).
+  def self.find_all_with_content_counters
+    Tag.joins(:contents).
       where(contents: { published: true }).
-      select(*Tag.column_names, 'COUNT(articles_tags.article_id) as article_counter').
+      select(*Tag.column_names, 'COUNT(contents_tags.content_id) as content_counter').
       group(*Tag.column_names).
-      order('article_counter DESC').limit(1000)
+      order('content_counter DESC').limit(1000)
   end
 
   def self.find_with_char(char)
@@ -49,8 +49,8 @@ class Tag < ActiveRecord::Base
     tags.map(&:display_name).sort.map { |name| name =~ / / ? "\"#{name}\"" : name }.join ', '
   end
 
-  def published_articles
-    articles.already_published
+  def published_contents
+    contents.already_published
   end
 
   def permalink

--- a/publify_core/app/views/admin/tags/_index_and_form.html.erb
+++ b/publify_core/app/views/admin/tags/_index_and_form.html.erb
@@ -48,7 +48,7 @@
             <%= link_to tag.display_name, edit_admin_tag_path(tag), { class: 'edit' } %>
             <%= link_to content_tag(:span, '', class: 'glyphicon glyphicon-pencil'), edit_admin_tag_path(tag), { class: 'btn btn-primary btn-xs btn-action' } %>
             <%= link_to content_tag(:span, '', class: 'glyphicon glyphicon-trash'), admin_tag_path(tag), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs btn-action' %>
-            <%= link_to_permalink(tag, "#{tag.articles.size} <span class='glyphicon glyphicon-link'></span>".html_safe, nil, 'btn btn-success btn-xs').html_safe %>
+            <%= link_to_permalink(tag, "#{tag.contents.size} <span class='glyphicon glyphicon-link'></span>".html_safe, nil, 'btn btn-success btn-xs').html_safe %>
           </td>
           <td><%= tag.name %></td>
         </tr>

--- a/publify_core/db/migrate/20170528093024_move_resources_to_content.rb
+++ b/publify_core/db/migrate/20170528093024_move_resources_to_content.rb
@@ -1,0 +1,5 @@
+class MoveResourcesToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :resources, :article_id, :content_id
+  end
+end

--- a/publify_core/db/migrate/20170528094923_move_tags_to_content.rb
+++ b/publify_core/db/migrate/20170528094923_move_tags_to_content.rb
@@ -1,0 +1,6 @@
+class MoveTagsToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :articles_tags, :article_id, :content_id
+    rename_table :articles_tags, :contents_tags
+  end
+end

--- a/publify_core/spec/controllers/admin/content_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/content_controller_spec.rb
@@ -495,9 +495,9 @@ describe Admin::ContentController, type: :controller do
     end
 
     before do
-      create(:tag, name: 'foo', articles: [create(:article)])
-      create(:tag, name: 'bazz', articles: [create(:article)])
-      create(:tag, name: 'bar', articles: [create(:article)])
+      create(:tag, name: 'foo', contents: [create(:article)])
+      create(:tag, name: 'bazz', contents: [create(:article)])
+      create(:tag, name: 'bar', contents: [create(:article)])
     end
 
     it 'should return foo for keywords fo' do

--- a/publify_core/spec/controllers/tags_controller_spec.rb
+++ b/publify_core/spec/controllers/tags_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TagsController, type: :controller do
     before do
       create(:blog)
       @tag = create(:tag)
-      @tag.articles << create(:article)
+      @tag.contents << create(:article)
     end
 
     describe 'normally' do
@@ -40,7 +40,7 @@ RSpec.describe TagsController, type: :controller do
     describe 'with some articles' do
       before do
         @articles = create_list :article, 2
-        @tag.articles << @articles
+        @tag.contents << @articles
       end
 
       it 'should be successful' do
@@ -97,7 +97,7 @@ RSpec.describe TagsController, type: :controller do
     let(:parsed_body) { Capybara.string(response.body) }
 
     before(:each) do
-      create(:tag, name: 'foo', articles: [create(:article)])
+      create(:tag, name: 'foo', contents: [create(:article)])
       get 'show', params: { id: 'foo' }
     end
 
@@ -138,7 +138,7 @@ RSpec.describe TagsController, type: :controller do
     it 'article in tag should be password protected' do
       create(:blog)
       article = create(:article, password: 'password')
-      create(:tag, name: 'foo', articles: [article])
+      create(:tag, name: 'foo', contents: [article])
       get 'show', params: { id: 'foo' }
       assert_select('input[id="article_password"]')
     end
@@ -148,7 +148,7 @@ RSpec.describe TagsController, type: :controller do
     before(:each) do
       @blog = create(:blog)
       @a = create(:article)
-      @foo = create(:tag, name: 'foo', articles: [@a])
+      @foo = create(:tag, name: 'foo', contents: [@a])
     end
 
     describe 'keywords' do

--- a/publify_core/spec/dummy/db/schema.rb
+++ b/publify_core/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160701062604) do
+ActiveRecord::Schema.define(version: 20170528093024) do
 
   create_table "articles_tags", id: false, force: :cascade do |t|
     t.integer "article_id"
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20160701062604) do
     t.string   "mime"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "article_id"
+    t.integer  "content_id"
     t.boolean  "itunes_metadata"
     t.string   "itunes_author"
     t.string   "itunes_subtitle"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20160701062604) do
     t.string   "itunes_category"
     t.boolean  "itunes_explicit"
     t.integer  "blog_id",         null: false
-    t.index ["article_id"], name: "index_resources_on_article_id"
+    t.index ["content_id"], name: "index_resources_on_content_id"
   end
 
   create_table "sidebars", force: :cascade do |t|

--- a/publify_core/spec/dummy/db/schema.rb
+++ b/publify_core/spec/dummy/db/schema.rb
@@ -10,14 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170528093024) do
-
-  create_table "articles_tags", id: false, force: :cascade do |t|
-    t.integer "article_id"
-    t.integer "tag_id"
-    t.index ["article_id"], name: "index_articles_tags_on_article_id"
-    t.index ["tag_id"], name: "index_articles_tags_on_tag_id"
-  end
+ActiveRecord::Schema.define(version: 20170528094923) do
 
   create_table "blogs", force: :cascade do |t|
     t.text   "settings"
@@ -39,7 +32,6 @@ ActiveRecord::Schema.define(version: 20170528093024) do
     t.integer  "text_filter_id"
     t.text     "whiteboard"
     t.string   "name"
-    t.boolean  "published",      default: false
     t.boolean  "allow_pings"
     t.boolean  "allow_comments"
     t.datetime "published_at"
@@ -48,10 +40,17 @@ ActiveRecord::Schema.define(version: 20170528093024) do
     t.text     "settings"
     t.string   "post_type",      default: "read"
     t.integer  "blog_id",                         null: false
+    t.boolean  "published",      default: false
     t.index ["id", "type"], name: "index_contents_on_id_and_type"
-    t.index ["published"], name: "index_contents_on_published"
     t.index ["text_filter_id"], name: "index_contents_on_text_filter_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
+  end
+
+  create_table "contents_tags", id: false, force: :cascade do |t|
+    t.integer "content_id"
+    t.integer "tag_id"
+    t.index ["content_id"], name: "index_contents_tags_on_content_id"
+    t.index ["tag_id"], name: "index_contents_tags_on_tag_id"
   end
 
   create_table "feedback", force: :cascade do |t|

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -264,13 +264,13 @@ describe Article, type: :model do
 
   it 'test_destroy_file_upload_associations' do
     a = create(:article)
-    create(:resource, article: a)
-    create(:resource, article: a)
+    create(:resource, content: a)
+    create(:resource, content: a)
     assert_equal 2, a.resources.size
     a.resources << create(:resource)
     assert_equal 3, a.resources.size
     a.destroy
-    assert_equal 0, Resource.where(article_id: a.id).size
+    assert_equal 0, Resource.where(content_id: a.id).size
   end
 
   describe '#interested_users' do

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -208,8 +208,8 @@ describe Article, type: :model do
   it 'test_find_published_by_tag_name' do
     art1 = create(:article)
     art2 = create(:article)
-    create(:tag, name: 'foo', articles: [art1, art2])
-    articles = Tag.find_by(name: 'foo').published_articles
+    create(:tag, name: 'foo', contents: [art1, art2])
+    articles = Tag.find_by(name: 'foo').published_contents
     assert_equal 2, articles.size
   end
 

--- a/publify_core/spec/models/tag_spec.rb
+++ b/publify_core/spec/models/tag_spec.rb
@@ -41,18 +41,18 @@ describe Tag, type: :model do
     expect(a.tags.sort_by(&:id)).to eq([foo, bar].sort_by(&:id))
   end
 
-  it 'find_all_with_article_counters finds 2 tags' do
+  it 'find_all_with_content_counters finds 2 tags' do
     a = create(:article, title: 'an article a')
     b = create(:article, title: 'an article b')
     c = create(:article, title: 'an article c')
-    create(:tag, name: 'foo', articles: [a, b, c])
-    create(:tag, name: 'bar', articles: [a, b])
-    tags = Tag.find_all_with_article_counters
+    create(:tag, name: 'foo', contents: [a, b, c])
+    create(:tag, name: 'bar', contents: [a, b])
+    tags = Tag.find_all_with_content_counters
     expect(tags.entries.size).to eq(2)
     expect(tags.first.name).to eq('foo')
-    expect(tags.first.article_counter).to eq(3)
+    expect(tags.first.content_counter).to eq(3)
     expect(tags.last.name).to eq('bar')
-    expect(tags.last.article_counter).to eq(2)
+    expect(tags.last.content_counter).to eq(2)
     expect(tags.first.blog).to eq blog
   end
 
@@ -67,8 +67,8 @@ describe Tag, type: :model do
     it 'should return only published articles' do
       published_art = FactoryGirl.create(:article)
       draft_art = FactoryGirl.create(:article, published_at: nil, published: false, state: 'draft')
-      art_tag = FactoryGirl.create(:tag, name: 'art', articles: [published_art, draft_art])
-      expect(art_tag.published_articles.size).to eq(1)
+      art_tag = FactoryGirl.create(:tag, name: 'art', contents: [published_art, draft_art])
+      expect(art_tag.published_contents.size).to eq(1)
     end
   end
 

--- a/publify_textfilter_code/spec/dummy/db/migrate/20170528164322_move_resources_to_content.publify_core_engine.rb
+++ b/publify_textfilter_code/spec/dummy/db/migrate/20170528164322_move_resources_to_content.publify_core_engine.rb
@@ -1,0 +1,6 @@
+# This migration comes from publify_core_engine (originally 20170528093024)
+class MoveResourcesToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :resources, :article_id, :content_id
+  end
+end

--- a/publify_textfilter_code/spec/dummy/db/migrate/20170528164423_move_tags_to_content.publify_core_engine.rb
+++ b/publify_textfilter_code/spec/dummy/db/migrate/20170528164423_move_tags_to_content.publify_core_engine.rb
@@ -1,0 +1,7 @@
+# This migration comes from publify_core_engine (originally 20170528094923)
+class MoveTagsToContent < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :articles_tags, :article_id, :content_id
+    rename_table :articles_tags, :contents_tags
+  end
+end

--- a/publify_textfilter_code/spec/dummy/db/schema.rb
+++ b/publify_textfilter_code/spec/dummy/db/schema.rb
@@ -10,14 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170528164322) do
-
-  create_table "articles_tags", id: false, force: :cascade do |t|
-    t.integer "article_id"
-    t.integer "tag_id"
-    t.index ["article_id"], name: "index_articles_tags_on_article_id"
-    t.index ["tag_id"], name: "index_articles_tags_on_tag_id"
-  end
+ActiveRecord::Schema.define(version: 20170528164423) do
 
   create_table "blogs", force: :cascade do |t|
     t.text   "settings"
@@ -52,6 +45,13 @@ ActiveRecord::Schema.define(version: 20170528164322) do
     t.index ["published"], name: "index_contents_on_published"
     t.index ["text_filter_id"], name: "index_contents_on_text_filter_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
+  end
+
+  create_table "contents_tags", id: false, force: :cascade do |t|
+    t.integer "content_id"
+    t.integer "tag_id"
+    t.index ["content_id"], name: "index_contents_tags_on_content_id"
+    t.index ["tag_id"], name: "index_contents_tags_on_tag_id"
   end
 
   create_table "feedback", force: :cascade do |t|

--- a/publify_textfilter_code/spec/dummy/db/schema.rb
+++ b/publify_textfilter_code/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160716093739) do
+ActiveRecord::Schema.define(version: 20170528164322) do
 
   create_table "articles_tags", id: false, force: :cascade do |t|
     t.integer "article_id"
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20160716093739) do
     t.string   "mime"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "article_id"
+    t.integer  "content_id"
     t.boolean  "itunes_metadata"
     t.string   "itunes_author"
     t.string   "itunes_subtitle"
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20160716093739) do
     t.string   "itunes_category"
     t.boolean  "itunes_explicit"
     t.integer  "blog_id",         null: false
-    t.index ["article_id"], name: "index_resources_on_article_id"
+    t.index ["content_id"], name: "index_resources_on_content_id"
   end
 
   create_table "sidebars", force: :cascade do |t|


### PR DESCRIPTION
By moving some relations to the Content superclass, we can preload all relations needed in the articles index.