### PR TITLE
Correctly set tag page title and description

### DIFF
--- a/publify_core/app/controllers/tags_controller.rb
+++ b/publify_core/app/controllers/tags_controller.rb
@@ -21,8 +21,8 @@ class TagsController < ContentController
         if @articles.empty?
           raise ActiveRecord::RecordNotFound
         else
-          @page_title = this_blog.tag_title_template.to_title(@tag, this_blog, params)
-          @description = @tag.description.to_s
+          @page_title = this_blog.tag_title_template.to_title(@tag, this_blog, params).strip
+          @description = this_blog.tag_desc_template.to_title(@tag, this_blog, params).strip
           @keywords = this_blog.meta_keywords
           render template_name(params[:id])
         end

--- a/publify_core/spec/controllers/articles_controller_spec.rb
+++ b/publify_core/spec/controllers/articles_controller_spec.rb
@@ -35,7 +35,7 @@ describe ArticlesController, 'base', type: :controller do
       end
 
       it 'should have good title' do
-        expect(response.body).to have_selector('title', text: 'test blog | test subtitles', visible: false)
+        expect(response.body).to have_selector('title', text: 'test blog | test subtitle', visible: false)
       end
     end
   end

--- a/publify_core/spec/controllers/tags_controller_spec.rb
+++ b/publify_core/spec/controllers/tags_controller_spec.rb
@@ -66,9 +66,14 @@ RSpec.describe TagsController, type: :controller do
         expect(controller).to have_received(:render).with('foo')
       end
 
-      it 'should set the page title to "Tag foo"' do
+      it 'assigns the correct page title' do
         do_get
-        expect(assigns[:page_title]).to eq('Tag: foo | test blog ')
+        expect(assigns[:page_title]).to eq 'Tag: foo | test blog'
+      end
+
+      it 'assigns the correct description' do
+        do_get
+        expect(assigns(:description)).to eq 'foo | test blog | test subtitle'
       end
 
       it 'should render the atom feed for /articles/tag/foo.atom' do

--- a/publify_core/spec/factories.rb
+++ b/publify_core/spec/factories.rb
@@ -148,7 +148,7 @@ FactoryGirl.define do
     limit_article_display 2
     sp_url_limit 3
     plugin_avatar ''
-    blog_subtitle 'test subtitles'
+    blog_subtitle 'test subtitle'
     limit_rss_display 10
     geourl_location ''
     default_allow_pings false


### PR DESCRIPTION
Ensures:
- page title has no extra white space
- description is not empty and uses correct template

Fixes #305.