### PR TITLE
Clean up feedback urls

### DIFF
--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -262,10 +262,6 @@ class Article < Content
     user.admin? || user_id == user.id
   end
 
-  def already_ping?(url)
-    pings.map(&:url).include?(url)
-  end
-
   def allow_comments?
     return allow_comments unless allow_comments.nil?
     blog.default_allow_comments
@@ -286,14 +282,6 @@ class Article < Content
 
   def published_feedback
     feedback.published.oldest_first
-  end
-
-  def html_urls_to_ping
-    urls_to_ping = []
-    html_urls.delete_if { |url| already_ping?(url) }.uniq.each do |url_to_ping|
-      urls_to_ping << pings.build('url' => url_to_ping)
-    end
-    urls_to_ping
   end
 
   private

--- a/publify_core/app/views/articles/read.html.erb
+++ b/publify_core/app/views/articles/read.html.erb
@@ -9,7 +9,7 @@
   <a name="comments"></a><h4 class="blueblk"><%= t('.comments') %></h4>
   <% unless @article.comments_closed? %>
     <p class="postmetadata alt">
-      <small><a href="#respond"><%= t(".leave_a_response")%></a></small>
+    <small><a href="#respond"><%= t(".leave_a_response")%></a></small>
     </p>
   <% end %>
   <%= render "articles/comment_list" %>
@@ -17,15 +17,17 @@
 
 <% if @article.allow_pings? %>
   <a name="trackbacks"></a><h4 class="blueblk"><%= t(".trackbacks")%></h4>
-  <p>
+  <% unless @article.pings_closed? %>
+    <p>
     <%= t(".use_the_following_link_to_trackback")%>:<br>
     <span class="light-bg"><%= @article.trackback_url %></span>
     </p>
-    <% unless @article.published_trackbacks.blank? %>
-      <ol id="trackbackList" class="trackback-list">
-        <%= render(partial: "trackback", collection: @article.published_trackbacks) %>
-      </ol>
-    <% end %>
+  <% end %>
+  <% unless @article.published_trackbacks.blank? %>
+    <ol id="trackbackList" class="trackback-list">
+      <%= render(partial: "trackback", collection: @article.published_trackbacks) %>
+    </ol>
+  <% end %>
 <% end %>
 
 <p class="postmetadata alt">

--- a/publify_core/app/views/articles/read.html.erb
+++ b/publify_core/app/views/articles/read.html.erb
@@ -31,9 +31,6 @@
 <p class="postmetadata alt">
   <small>
   <a href="<%= @article.feed_url('rss') %>" title="RSS Feed"><%= t(".rss_feed")%></a>
-<% if @article.allow_pings? %>
-  <a href="<%= @article.trackback_url %>" ><%= t(".trackback_uri")%></a>
-<% end %>
   </small>
 </p>
 

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -676,7 +676,6 @@ da:
       edit: Rediger
       leave_a_response: Skriv en kommentar
       rss_feed: RSS Feed for denne artikel
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Brug følgende link til lave trackback fra din egen side
     trackback:

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -676,7 +676,6 @@ de:
       edit: Bearbeiten
       leave_a_response: Einen Kommentar hinterlassen
       rss_feed: RSS Feed für diesen Artikel
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Verwenden Sie den folgenden Link zur Rückverlinkung von Ihrer eigenen Seite
     trackback:

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -676,7 +676,6 @@ en:
       edit: Edit
       leave_a_response: Leave a response
       rss_feed: RSS feed
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Use the following link to trackback from your own site
     trackback:

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -676,7 +676,6 @@ es-MX:
       edit: Edit
       leave_a_response: Deja un comentario
       rss_feed: Feed RSS para este art&iacute;culo
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Usa el siguiente link para crear un trackback desde tu propio sitio
     trackback:

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -676,7 +676,6 @@ fr:
       edit: Éditer
       leave_a_response: Réagir à ce billet
       rss_feed: Flux RSS
-      trackback_uri: Trackback URI
       trackbacks: Rétroliens
       use_the_following_link_to_trackback: Utilisez le lien ci-dessous pour envoyer un rétrolien depuis votre site
     trackback:

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -676,7 +676,6 @@ he:
       edit: Edit
       leave_a_response: הגב
       rss_feed: מזין RSS לכתבה זו
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: השתמש בקישור הבא כדי לעקוב-חזרה מהאתר שלך
     trackback:

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -676,7 +676,6 @@ it:
       edit: Edit
       leave_a_response: Commenta
       rss_feed: Feed RSS per questo post
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Usa il link seguente per fare un trackback dal tuo sito
     trackback:

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -676,7 +676,6 @@ ja:
       edit: Edit
       leave_a_response: コメントを書く
       rss_feed: この記事のRSSフィード
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: トラックバックリンク
     trackback:

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -676,7 +676,6 @@ lt:
       edit: Redaguoti
       leave_a_response: Palikti atsakymą
       rss_feed: šio įrašo RSS
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Dienoraščio nuoroda (trackback)
     trackback:

--- a/publify_core/config/locales/nb-NO.yml
+++ b/publify_core/config/locales/nb-NO.yml
@@ -676,7 +676,6 @@ nb-NO:
       edit: Rediger
       leave_a_response: Skriv en kommentar
       rss_feed: RSS-feed for denne artikkel
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Bruk følgende lenke for å opprette trackback fra din egen side
     trackback:

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -676,7 +676,6 @@ nl:
       edit: Bewerken
       leave_a_response: Geef een reactie
       rss_feed: RSS feed voor dit bericht
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Gebruik de volgende link voor een trackback van jouw site
     trackback:

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -676,7 +676,6 @@ pl:
       edit: Zmień
       leave_a_response: Skomentuj
       rss_feed: Subskrypcja RSS dla tego wpisu
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Użyj następującego trackbacka na swojej stronie
     trackback:

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -676,7 +676,6 @@ pt-BR:
       edit: Editar
       leave_a_response: Deixar um comentário
       rss_feed: Feed RSS para este artigo
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Use o seguinte link para criar um trackback para seu próprio site.
     trackback:

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -676,7 +676,6 @@ ro:
       edit: Editare
       leave_a_response: Comentează
       rss_feed: Flux RSS pentru acest articol
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Folosește link-ul următor pentru a realiza o retrolegătură de la site-ul tău
     trackback:

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -676,7 +676,6 @@ ru:
       edit: Редактировать
       leave_a_response: Оставить отзыв
       rss_feed: RSS feed
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: Use the following link to trackback from your own site
     trackback:

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -676,7 +676,6 @@ zh-CN:
       edit: 修改
       leave_a_response: 離開一個回應
       rss_feed: 為本篇提供RSS
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: 從你所屬的網點用隨後的連結去引用
     trackback:

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -676,7 +676,6 @@ zh-TW:
       edit: 修改
       leave_a_response: 離開一個回應
       rss_feed: 為本篇提供RSS
-      trackback_uri: Trackback URI
       trackbacks: Trackbacks
       use_the_following_link_to_trackback: 從你所屬的網點用隨後的連結去引用
     trackback:


### PR DESCRIPTION
This mainly avoids web clients following the trackback link, which only supports post requests.