### PR TITLE
Fix theme javascripts action

### DIFF
--- a/publify_core/Manifest.txt
+++ b/publify_core/Manifest.txt
@@ -361,5 +361,6 @@ lib/text_filter_plugin.rb
 lib/theme.rb
 lib/transforms.rb
 themes/plain/about.markdown
+themes/plain/javascripts/theme.js
 themes/plain/preview.png
 themes/plain/stylesheets/theme.css

--- a/publify_core/app/controllers/theme_controller.rb
+++ b/publify_core/app/controllers/theme_controller.rb
@@ -1,10 +1,13 @@
 class ThemeController < ContentController
+  # Allow javascripts via Get request
+  skip_before_action :verify_authenticity_token, only: :javascripts
+
   def stylesheets
     render_theme_item(:stylesheets, params[:filename], 'text/css; charset=utf-8')
   end
 
-  def javascript
-    render_theme_item(:javascript, params[:filename], 'text/javascript; charset=utf-8')
+  def javascripts
+    render_theme_item(:javascripts, params[:filename], 'text/javascript; charset=utf-8')
   end
 
   def images

--- a/publify_core/config/routes.rb
+++ b/publify_core/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
   # ThemeController
   scope controller: 'theme', filename: /.*/ do
     get 'stylesheets/theme/:filename', action: 'stylesheets', format: false
-    get 'javascripts/theme/:filename', action: 'javascript', format: false
+    get 'javascripts/theme/:filename', action: 'javascripts', format: false
     get 'images/theme/:filename', action: 'images', format: false
     get 'fonts/theme/:filename', action: 'fonts', format: false
   end

--- a/publify_core/spec/controllers/theme_controller_spec.rb
+++ b/publify_core/spec/controllers/theme_controller_spec.rb
@@ -13,6 +13,14 @@ describe ThemeController, type: :controller do
     assert_equal 'inline; filename="theme.css"', @response.headers['Content-Disposition']
   end
 
+  it 'test_javascripts' do
+    get :javascripts, params: { filename: 'theme.js' }
+    assert_response :success
+    assert_equal 'text/javascript', @response.content_type
+    assert_equal 'utf-8', @response.charset
+    assert_equal 'inline; filename="theme.js"', @response.headers['Content-Disposition']
+  end
+
   it 'test_malicious_path' do
     get :stylesheets, params: { filename: '../../../config/database.yml' }
     expect(response).to be_not_found


### PR DESCRIPTION
To be consistent, update `ThemeController` action `javascript` to `javascripts`.

Skip CSRF protection for action `javascripts` so that js via Get request loaded successfully.

Related Rails Issue: https://github.com/rails/rails/pull/13345
