### PR TITLE
Clean up references to old domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,5 +431,5 @@ platform][4].
 [1]: http://t37.net/here-comes-the-time-to-hand-over-your-open-source-project.html
 [2]: http://t37.net/is-coding-a-blogging-engine-still-worth-the-effort-in-2013-and-other-thoughts-about-content-publishing-tools.html
 [3]: https://github.com/publify/typographic
-[4]: http://demo.publify.co/
+[4]: https://demo-publify.herokuapp.com/
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,6 @@ module Publify
   require 'publify_sidebar'
   require 'publify_textfilters'
   require 'publify_avatar_gravatar'
-  require 'publify_version'
 
   Theme.register_themes "#{Rails.root}/themes"
 end

--- a/lib/publify_version.rb
+++ b/lib/publify_version.rb
@@ -1,5 +1,0 @@
-TYPO_MAJOR = '9'.freeze
-TYPO_SUB = '1'.freeze
-TYPO_MINOR = '0'.freeze
-PUBLIFY_VERSION = "#{TYPO_MAJOR}.#{TYPO_SUB}.#{TYPO_MINOR}".freeze
-PUBLIFY_VERSION_URL = 'http://blog.publify.co/version.txt'.freeze

--- a/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = PublifyAmazonSidebar::VERSION
   s.authors     = ['Matijs van Zuijlen']
   s.email       = ['matijs@matijs.net']
-  s.homepage    = 'https://publify.co'
+  s.homepage    = 'https://publify.github.io/'
   s.summary     = 'Amazon sidebar for the Publify blogging system.'
   s.description = 'Amazon sidebar for the Publify blogging system.'
   s.license     = 'MIT'

--- a/publify_core/app/controllers/admin/dashboard_controller.rb
+++ b/publify_core/app/controllers/admin/dashboard_controller.rb
@@ -29,26 +29,6 @@ class Admin::DashboardController < Admin::BaseController
 
     @statspam = Comment.spam.count
     @inbound_links = inbound_links
-    publify_version
-  end
-
-  def publify_version
-    version = nil
-    begin
-      open(PUBLIFY_VERSION_URL) do |http|
-        publify_version = http.read[0..5]
-        version = publify_version.split('.')
-      end
-    rescue
-      return
-    end
-    if version[0].to_i > TYPO_MAJOR.to_i
-      flash[:error] = I18n.t('admin.dashboard.publify_version.error')
-    elsif version[1].to_i > TYPO_SUB.to_i
-      flash[:warning] = I18n.t('admin.dashboard.publify_version.warning')
-    elsif version[2].to_i > TYPO_MINOR.to_i
-      flash[:notice] = I18n.t('admin.dashboard.publify_version.notice')
-    end
   end
 
   private

--- a/publify_core/app/models/blog.rb
+++ b/publify_core/app/models/blog.rb
@@ -89,7 +89,7 @@ class Blog < ApplicationRecord
     Twitter: your Twitter username.
 
     /* SITE */
-    Software: Publify [http://publify.co] #{PublifyCore::VERSION}
+    Software: Publify [https://publify.github.io/] #{PublifyCore::VERSION}
   TEXT
   setting :index_categories, :boolean, true # deprecated but still needed for backward compatibility
   setting :unindex_categories, :boolean, false

--- a/publify_core/app/models/static_sidebar.rb
+++ b/publify_core/app/models/static_sidebar.rb
@@ -1,7 +1,7 @@
 class StaticSidebar < Sidebar
   DEFAULT_TEXT = '
 <ul>
-  <li><a href="http://www.publify.co/" title="Publify">Publify</a></li>
+  <li><a href="https://publify.github.io/" title="Publify">Publify</a></li>
   <li><a href="http://t37.net/" title="Le Rayon UX">Frédéric</a></li>
   <li><a href="http://www.matijs.net/" title="Matijs">Matijs</a></li>
   <li><a href="http://elsif.fr/" title="Yannick">Yannick</a></li>

--- a/publify_core/app/views/admin/dashboard/_overview.html.erb
+++ b/publify_core/app/views/admin/dashboard/_overview.html.erb
@@ -18,6 +18,6 @@
   </p>
   <% end %>
   <p>
-  <%= t(".help_explain_html", doc_link: link_to(t('.read_our_documentation'), 'http://publify.co')) %>
+  <%= t(".help_explain_html", doc_link: link_to(t('.read_our_documentation'), 'https://publify.github.io/')) %>
   </p>
 </div>

--- a/publify_core/app/views/layouts/accounts.html.erb
+++ b/publify_core/app/views/layouts/accounts.html.erb
@@ -16,7 +16,7 @@
       <div class="col-md-4 col-md-offset-4">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h1 class='panel-title'><%= link_to("Publify", "http://publify.co") %></h1>
+            <h1 class='panel-title'><%= link_to("Publify", "https://publify.github.io") %></h1>
           </div>
           <div class="panel-body">
             <%= render 'shared/flash', flash: flash %>

--- a/publify_core/app/views/layouts/default.html.erb
+++ b/publify_core/app/views/layouts/default.html.erb
@@ -25,7 +25,7 @@
 
       <div class="footer">
         <p class="legal">
-        <%= t(".powered_by_html", powered_by: link_to('Publify', 'http://publify.co')) %>
+        <%= t(".powered_by_html", powered_by: link_to('Publify', 'https://publify.github.io')) %>
         </p>
       </div>
     </div>

--- a/publify_core/app/views/meta_sidebar/_content.html.erb
+++ b/publify_core/app/views/meta_sidebar/_content.html.erb
@@ -3,6 +3,6 @@
   <ul>
     <li><%= link_to(t('.rss_feed'), feed_rss) %></li>
     <li><%= link_to(t('.admin'), :controller => 'admin/dashboard') %></li>
-    <li><a href="http://publify.co"><%= t('.powered_by_publify') %></a></li>
+    <li><a href="https://publify.github.io"><%= t('.powered_by_publify') %></a></li>
   </ul>
 </div>

--- a/publify_core/app/views/setup/index.html.erb
+++ b/publify_core/app/views/setup/index.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag :action=> 'index' do %>
   <div class='alert alert-info'>
-    <small><%= t(".welcome_to_your_blog_setup", publify: link_to("Publify", 'http://publify.co'))%></small>
+    <small><%= t(".welcome_to_your_blog_setup", publify: link_to("Publify", 'https://publify.github.io/'))%></small>
   </div>
   <div class='form-group'>
     <%= text_field(:setting, :blog_name, { :class=> 'form-control', :placeholder => t(".blog_name")})%>

--- a/publify_core/app/views/shared/_atom_header.atom.builder
+++ b/publify_core/app/views/shared/_atom_header.atom.builder
@@ -1,4 +1,4 @@
 feed.title(feed_title)
 feed.subtitle(this_blog.blog_subtitle, 'type' => 'html') if this_blog.blog_subtitle.present?
 feed.updated items.first.updated_at if items.first
-feed.generator 'Publify', uri: 'http://www.publify.co', version: PublifyCore::VERSION
+feed.generator 'Publify', uri: 'https://publify.github.io', version: PublifyCore::VERSION

--- a/publify_core/config/initializers/devise.rb
+++ b/publify_core/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'default@publify.co'
+  config.mailer_sender = 'change-me@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -102,10 +102,6 @@ da:
         update_your_profile_or_change_your_password: opdatere din profil eller rette dit kodeord
         write_a_page: skrive en side
         write_a_post: skrive en artikel
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -102,10 +102,6 @@ de:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: eine Seite schreiben
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -102,10 +102,6 @@ en:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: write a page
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -102,10 +102,6 @@ es-MX:
         update_your_profile_or_change_your_password: actualizar tu perfil o cambiar su contrasena
         write_a_page: escribir una pagina
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -102,10 +102,6 @@ fr:
         update_your_profile_or_change_your_password: Mettre votre profil à jour ou changer votre mot de passe
         write_a_page: Publier une page statique
         write_a_post: Écrire un article
-      publify_version:
-        error: Vous avez au moins une version majeure de Publify de retard. Vous devriez immédiatement vous mettre à jour. Téléchargez et installez <a href='http://publify.co/stable.tgz'>la dernière version de Publify</a>
-        notice: Une nouvelle version de Publify est disponible. Pouquoi n'installeriez-vous pas <a href='http://publify.co/stable.tgz'>la dernière version de Publify</a> ?
-        warning: Une nouvelle version de Publify est disponible. Celle-ci contient probablement d'importants correctifs. Pourquoi ne téléchargeriez-vous pas <a href='http://publify.co/stable.tgz'>la dernière version de Publify</a> ?
       welcome:
         approved_count:
           one: 1 approuvé

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -102,10 +102,6 @@ he:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: לכתוב דף
         write_a_post: לכתוב כתבה
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -102,10 +102,6 @@ it:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: write a page
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -102,10 +102,6 @@ ja:
         update_your_profile_or_change_your_password: プロフィールを編集したりパスワードを変更する
         write_a_page: ページを作成する
         write_a_post: 記事を投稿する
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -102,10 +102,6 @@ lt:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: write a page
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/nb-NO.yml
+++ b/publify_core/config/locales/nb-NO.yml
@@ -102,10 +102,6 @@ nb-NO:
         update_your_profile_or_change_your_password: oppdatere profilen din eller endre passordet ditt
         write_a_page: skrive en side
         write_a_post: skrive en artikkel
-      publify_version:
-        error: Du bruker en gammel versjon av Publify. Du bør oppgradere snarest. Last ned og installer <a href='http://publify.co/stable.tgz'>siste Publify-versjon</a>
-        notice: Det finnes en ny versjon av Publify. Hva med å oppgradere til <a href='http://publify.co/stable.tgz'>siste Publify-versjon</a>?
-        warning: Det finnes en ny versjon av Publify som kan inneholde viktige feilrettinger. Hva med å oppgradere til <a href='http://publify.co/stable.tgz'>siste Publify-versjon</a>?
       welcome:
         approved_count:
           one: 1 godkjent

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -102,10 +102,6 @@ nl:
         update_your_profile_or_change_your_password: je profiel bijwerken of je wachtwoord wijzigen
         write_a_page: een pagina schrijven
         write_a_post: een post schrijven
-      publify_version:
-        error: You are late from at least one major version of Publify. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a> ?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a> ?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -102,10 +102,6 @@ pl:
         update_your_profile_or_change_your_password: zaktualizować profil lub zmienić hasło
         write_a_page: utworzyć stronę
         write_a_post: utworzyć wpis
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 zaakceptowany

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -102,10 +102,6 @@ pt-BR:
         update_your_profile_or_change_your_password: atualizar seu perfil ou mudar sua senha
         write_a_page: escrever uma página
         write_a_post: escrever uma postagem
-      publify_version:
-        error: Você está desatualizado de pelo menos uma versão principal do Publify. Você deve atualizar imediatamente. Baixe e instale <a href='http://publify.co/stable.tgz'>a versão mais recente do Publify</a>
-        notice: Existe uma nova versão disponível do Publify. Porque você não atualiza para <a href='http://publify.co/stable.tgz'>a versão mais recente do Publify</a> ?
-        warning: Existe uma nova versão do Publify que contém correções importantes. Porque você não atualiza para <a href='http://publify.co/stable.tgz'>a versão mais recente do Publify</a> ?
       welcome:
         approved_count:
           one: 1 aprovado

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -102,10 +102,6 @@ ro:
         update_your_profile_or_change_your_password: update your profile or change your password
         write_a_page: write a page
         write_a_post: write a post
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -102,10 +102,6 @@ ru:
         update_your_profile_or_change_your_password: изменить свой профиль или поменять пароль
         write_a_page: создать страницу
         write_a_post: написать пост
-      publify_version:
-        error: You are late from at least one major version of Publify. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a> ?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a> ?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -102,10 +102,6 @@ zh-CN:
         update_your_profile_or_change_your_password: 更新资料或者修改密码
         write_a_page: 写一个页面
         write_a_post: 写一篇文章
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -102,10 +102,6 @@ zh-TW:
         update_your_profile_or_change_your_password: 更新資料或者修改密碼
         write_a_page: 寫一個頁面
         write_a_post: 寫一篇文章
-      publify_version:
-        error: You are at least one major version of Publify out of date. You should upgrade immediately. Download and install <a href='http://publify.co/stable.tgz'>the latest Publify version</a>
-        notice: There's a new version of Publify available. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
-        warning: There's a new version of Publify available which may contain important bug fixes. Why don't you upgrade to <a href='http://publify.co/stable.tgz'>the latest Publify version</a>?
       welcome:
         approved_count:
           one: 1 approved

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Matijs van Zuijlen', 'Yannick François',
                    'Thomas Lecavellier', 'Frédéric de Villamil']
   s.email       = ['matijs@matijs.net']
-  s.homepage    = 'https://publify.co'
+  s.homepage    = 'https://publify.github.io/'
   s.summary     = 'Core engine for the Publify blogging system.'
   s.description = 'Core engine for the Publify blogging system, formerly known as Typo.'
   s.license     = 'MIT'

--- a/publify_core/spec/controllers/admin/feedback_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/feedback_controller_spec.rb
@@ -136,7 +136,7 @@ describe Admin::FeedbackController, type: :controller do
 
     describe 'create action' do
       def base_comment(options = {})
-        { 'body' => 'a new comment', 'author' => 'Me', 'url' => 'http://publify.co', 'email' => 'dev@publify.co' }.merge(options)
+        { 'body' => 'a new comment', 'author' => 'Me', 'url' => 'https://bar.com/', 'email' => 'foo@bar.com' }.merge(options)
       end
 
       describe 'by get access' do

--- a/publify_core/spec/controllers/admin/pages_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/pages_controller_spec.rb
@@ -96,7 +96,7 @@ describe Admin::PagesController, type: :controller do
 
     context 'should update a post' do
       before(:each) do
-        post :update, params: { id: page.id, page: { name: 'markdown-page', title: 'Markdown Page', body: 'Adding a [link](http://www.publify.co/) here' } }
+        post :update, params: { id: page.id, page: { name: 'markdown-page', title: 'Markdown Page', body: 'Adding a [link](https://publify.github.io/) here' } }
       end
 
       it { expect(response).to redirect_to(action: :index) }

--- a/publify_textfilter_code/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code/publify_textfilter_code.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = PublifyTextfilterCode::VERSION
   s.authors     = ['Matijs van Zuijlen']
   s.email       = ['matijs@matijs.net']
-  s.homepage    = 'https://publify.co'
+  s.homepage    = 'https://publify.github.io/'
   s.summary     = 'Code text filter for the Publify blogging system.'
   s.description = 'Code text filter sidebar for the Publify blogging system.'
   s.license     = 'MIT'


### PR DESCRIPTION
Replaces or removes all references to the old `publify.co` domain.