### PR TITLE
Fix comment preview

### DIFF
--- a/publify_core/app/controllers/comments_controller.rb
+++ b/publify_core/app/controllers/comments_controller.rb
@@ -30,7 +30,7 @@ class CommentsController < BaseController
       return
     end
 
-    @comment = Comment.new(comment_params)
+    @comment = @article.comments.build(comment_params)
   end
 
   protected

--- a/publify_core/app/views/articles/_comment_preview.html.erb
+++ b/publify_core/app/views/articles/_comment_preview.html.erb
@@ -1,4 +1,4 @@
 <%= avatar_tag(email: comment.email, url: comment.url) %>
-<cite><strong><%=h @comment[:author] %></strong></cite>
+<cite><strong><%=h comment[:author] %></strong></cite>
 <%= t(".is_about_to_say")%>:<br>
-<%= @comment.html %>
+<%= comment.html %>

--- a/publify_core/spec/controllers/comments_controller_spec.rb
+++ b/publify_core/spec/controllers/comments_controller_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe CommentsController, type: :controller do
   let!(:blog) { create(:blog) }
   let(:article) { create(:article) }
-  let(:comment_params) { { body: 'content', author: 'bob', email: 'bob@home', url: 'http://bobs.home/' } }
+  let(:comment_params) do
+    { body: 'content', author: 'bob', email: 'bob@home', url: 'http://bobs.home/' }
+  end
 
   describe '#create' do
     context 'when using regular post' do
@@ -48,6 +50,28 @@ describe CommentsController, type: :controller do
 
       it 'renders the comment partial' do
         expect(response).to render_template('articles/comment')
+      end
+    end
+  end
+
+  describe '#preview' do
+    context 'when using xhr post' do
+      before do
+        post :preview, xhr: true, params: { comment: comment_params, article_id: article.id }
+      end
+
+      it 'assigns a comment with the given parameters' do
+        comment = assigns[:comment]
+        aggregate_failures do
+          expect(comment.author).to eq('bob')
+          expect(comment.body).to eq('content')
+          expect(comment.email).to eq('bob@home')
+          expect(comment.url).to eq('http://bobs.home/')
+        end
+      end
+
+      it 'assigns the article to the comment' do
+        expect(assigns[:comment].article).to eq article
       end
     end
   end


### PR DESCRIPTION
Comment preview is broken because the partial can't render the comment body. This fixes that by linking the article so the needed text filter can be found.