### PR TITLE
Drop support for generating humans.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See the changelogs for the individual engines for more details for releases 9.0 
 * Fix logic for rendering excerpts or whole posts (mvz)
 * Drop support for Ruby 2.2 (mvz)
 * Fix comment preview (mvz)
+* Drop support for humans.txt (mvz)
 
 ## 9.1.0 / 2018-04-19
 

--- a/publify_core/CHANGELOG.md
+++ b/publify_core/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Drop support for Ruby 2.2 (mvz)
 * Provide FactoryBot factories for general use (mvz)
 * Fix comment preview (mvz)
+* Drop support for humans.txt (mvz)
 
 ## 9.1.0 / 2018-04-19
 

--- a/publify_core/app/controllers/text_controller.rb
+++ b/publify_core/app/controllers/text_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class TextController < BaseController
-  def humans
-    render plain: this_blog.humans
-  end
-
   def robots
     render plain: this_blog.robots
   end

--- a/publify_core/app/views/admin/seo/_general.html.erb
+++ b/publify_core/app/views/admin/seo/_general.html.erb
@@ -93,17 +93,6 @@
 </fieldset>
 
 <fieldset class='form-horizontal'>
-  <legend><%= t(".human") %></legend>
-  <div class='form-group'>
-    <label class='control-label col-sm-4 col-md-3 col-lg-2' for="setting_humans"><%= t(".humans_txt") %></label>
-    <div class='col-sm-8 col-md-6 col-lg-4'>
-      <%= text_area(:setting, :humans, rows: 10, class: 'form-control') %>
-      <small class='help-block'><%= t(".explain_humans_txt") %></small>
-    </div>
-  </div>
-</fieldset>
-
-<fieldset class='form-horizontal'>
   <legend><%= t(".google") %></legend>
   <div class='form-group'>
     <label class='control-label col-sm-4 col-md-3 col-lg-2' for="setting_google_analytics"><%= t(".google_analytics") %></label>

--- a/publify_core/app/views/shared/_page_header.html.erb
+++ b/publify_core/app/views/shared/_page_header.html.erb
@@ -23,4 +23,3 @@
 
 <%= meta_tag 'og:site_name', this_blog.blog_name %>
 <%= meta_tag 'og:title', @article ? @article.title : @page_title %>
-<link ref='author' href="humans.txt">

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -333,7 +333,6 @@ da:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ da:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -333,7 +333,6 @@ de:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ de:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -333,7 +333,6 @@ en:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ en:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -333,7 +333,6 @@ es-MX:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ es-MX:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -333,7 +333,6 @@ fr:
         do_not_index_tags: Ne pas indexer les labels
         dofollow: Dofollow
         explain: Ici, vous pouve ajouter tout ce que vous souhaitez voir apparaître dans l'en-tête de votre blog, comme le code de suivi d'un service de statistiques.
-        explain_humans_txt: Il s'agit d'une initiative pour connaître les personnes derrière un site Internet. Il s'agit d'un fichier TXT qui contient des informations à propos des différentes personnes qui ont contribué à construire le site. http://humanstxt.org/
         explain_moderate_feedback: Si vous activez cette option, peut-être devriez-vous également activer la modération des commentaires.
         explain_rss_description: 'Vous pouvez utliser les tags suivants : %author% (nom de l''auteur), %blog_url% (URL du blog), %blog_name% (nom du blog) et %permalink_url% (lien vers l''article que vous souhaitez protéger)'
         explain_tag_index_html: Sélectionner cette option ajoutera le métalabel <code>noindex, follow</code> dans toutes les pages de chaque label. Cela les enlèvera des moteurs de recherche et préviendra ainsi des problèmes de contenu dupliqué.
@@ -341,8 +340,6 @@ fr:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Lien de validation des Google Webmaster Tools.
-        human: Humain
-        humans_txt: Humain
         indexing: Indexation
         meta_description: Meta description
         meta_keywords: Meta mots-clés

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -333,7 +333,6 @@ he:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ he:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -333,7 +333,6 @@ it:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ it:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -333,7 +333,6 @@ ja:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ ja:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: METAタグDescription
         meta_keywords: METAタグKeywords

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -333,7 +333,6 @@ lt:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ lt:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/nb-NO.yml
+++ b/publify_core/config/locales/nb-NO.yml
@@ -333,7 +333,6 @@ nb-NO:
         do_not_index_tags: Ikke indekser tagger
         dofollow: Dofollow
         explain: Her kan du legge til det du vil skal inkluderes i din applikasjons-header, som for eksempel tracking-kode for en analyseservice.
-        explain_humans_txt: Dette er et initiativ for å få kjennskap til menneskene bak et nettsted. Det er en txt-fil som inneholder informasjon om de forskjellig personene som har bidratt til å bygge nettstedet. http://humanstxt.org/
         explain_moderate_feedback: Det kan være en idé å moderere diskusjoner når du slår på denne
         explain_rss_description: 'Du kan bruke følgende tagger: %author% (forfatternavn), %blog_url% (blogg-URL), %blog_name% (bloggtittel) og %permalink_url% (en lenke til den artikkelen du vil beskytte)'
         explain_tag_index_html: Slår du på denne, vil metataggene <code>noindex, follow</code> bli lagt til på alle taggsider, og dermed fjerne dem fra søkemotorer og forhindre problemer med duplisert innhold
@@ -341,8 +340,6 @@ nb-NO:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools valideringslenke
-        human: Menneskene bak
-        humans_txt: humans.txt
         indexing: Indeksering
         meta_description: Metabeskrivelse
         meta_keywords: Metanøkkelord

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -333,7 +333,6 @@ nl:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ nl:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta-beschrijving
         meta_keywords: Meta-kewords

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -333,7 +333,6 @@ pl:
         do_not_index_tags: Nie indeksuj tagów
         dofollow: Dofollow
         explain: Tutaj możesz dodać dowolny kod, który ma się pojawić w nagłówku strony, np. kod do analizy ruchu na stronie.
-        explain_humans_txt: 'Jest to plik TXT, który zawiera informacje o ludziach, którzy współtworyli daną stronę internetową. Więcej informacji: http://humanstxt.org/'
         explain_moderate_feedback: Jeżeli to włączysz, być może będziesz chcieć moderować komentarze
         explain_rss_description: 'Możesz używać następujących tagów: %author% (autor), %blog_url% (adres tego bloga), %blog_name% (nazwa tego bloga) and %permalink_url% (link do artykułu, który chcesz chronić)'
         explain_tag_index_html: Zaznaczenie tej opcji spowoduje dodanie <code>noindex, follow</code> do każdej strony tagu, co spowoduje usunięcie z wyników wyszukiwania i uniknięcie duplikacji treści
@@ -341,8 +340,6 @@ pl:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indeksowanie
         meta_description: Opis
         meta_keywords: Słowa kluczowe

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -333,7 +333,6 @@ pt-BR:
         do_not_index_tags: Não indexar tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: É uma iniciativa saber as pessoas que estão por trás de um site. É um arquivo TXT que contém informações sobre as diferentes pessoas que contribuíram para o desenvolvimento do site. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ pt-BR:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Link de validação do Google Webmaster Tools
-        human: Humano
-        humans_txt: Human
         indexing: Indexando
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -333,7 +333,6 @@ ro:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ ro:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -333,7 +333,6 @@ ru:
         do_not_index_tags: Не индксировать теги
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ ru:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Индексация
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -333,7 +333,6 @@ zh-CN:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ zh-CN:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -333,7 +333,6 @@ zh-TW:
         do_not_index_tags: Do not index tags
         dofollow: Dofollow
         explain: Here you can add anything you want to appear in your application header, such as analytics service tracking code.
-        explain_humans_txt: It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website. http://humanstxt.org/
         explain_moderate_feedback: You may want to moderate feedback when turning this on
         explain_rss_description: 'You can use the following tags: %author% (author name), %blog_url% (this blog URL), %blog_name% (this blog title) and %permalink_url% (a link to the article you want to protect)'
         explain_tag_index_html: Checking this box will add <code>noindex, follow</code> meta tags in every tags page, removing them from search engines and preventing duplicate content issues
@@ -341,8 +340,6 @@ zh-TW:
         google: Google
         google_analytics: Google Analytics
         google_webmaster_tools_validation_link: Google Webmaster Tools validation link
-        human: Human
-        humans_txt: Human
         indexing: Indexing
         meta_description: Meta description
         meta_keywords: Meta keywords

--- a/publify_core/config/routes.rb
+++ b/publify_core/config/routes.rb
@@ -63,7 +63,6 @@ Rails.application.routes.draw do
   get '/notes/page/:page', to: 'notes#index', format: false
   get '/note/:permalink', to: 'notes#show', format: false
 
-  get '/humans', to: 'text#humans', format: 'txt'
   get '/robots', to: 'text#robots', format: 'txt'
 
   # TODO: Remove if possible

--- a/publify_core/spec/controllers/text_controller_spec.rb
+++ b/publify_core/spec/controllers/text_controller_spec.rb
@@ -5,13 +5,6 @@ require 'rails_helper'
 describe TextController, type: :controller do
   let!(:blog) { create(:blog) }
 
-  describe 'humans' do
-    before { get :humans, params: { format: 'txt' } }
-
-    it { expect(response).to be_successful }
-    it { expect(response.body).to eq(blog.humans) }
-  end
-
   describe 'robots' do
     before { get :robots, params: { format: 'txt' } }
 


### PR DESCRIPTION
The existing implementation was buggy:

- Links incorrectly used a relative URL
- Links abused rel='author'; We have another page for the author of a post.
- The provided route was incorrect when Publify is used in a sub-URI.
- The provided default was bad

In addition, the humans.txt concept does not seem to be a big hit. Users who want to provide a humans.txt file should just add one to their web server root manually.

Fixes #901.