### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
 
   gem 'capybara', '~> 3.9'
   gem 'factory_bot', '~> 4.11'
-  gem 'i18n-tasks', '0.9.27', require: false
+  gem 'i18n-tasks', '0.9.28', require: false
   gem 'pry', '~> 0.12.0'
   gem 'pry-rails', '~> 0.3.4'
   gem 'rspec-rails', '~> 3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
 
   gem 'capybara', '~> 3.9'
   gem 'factory_bot', '~> 4.11'
-  gem 'i18n-tasks', '~> 0.9.25', require: false
+  gem 'i18n-tasks', '0.9.27', require: false
   gem 'pry', '~> 0.12.0'
   gem 'pry-rails', '~> 0.3.4'
   gem 'rspec-rails', '~> 3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   gem 'capybara', '~> 3.9'
   gem 'factory_bot', '~> 4.11'
   gem 'i18n-tasks', '~> 0.9.25', require: false
-  gem 'pry', '~> 0.11.3'
+  gem 'pry', '~> 0.12.0'
   gem 'pry-rails', '~> 0.3.4'
   gem 'rspec-rails', '~> 3.4'
   gem 'simplecov', '~> 0.16.1', require: false

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -3,6 +3,7 @@ lt:
   articles:
     comment_counter:
       comments:
+        few: "%{count} Komentarai"
         one: 1 Komentaras
         other: "%{count} Komentarai"
         zero: no comments

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3,6 +3,8 @@ pl:
   articles:
     comment_counter:
       comments:
+        few: "%{count} komentarzy"
+        many: "%{count} komentarzy"
         one: 1 komentarz
         other: "%{count} komentarzy"
         zero: brak komentarzy

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -3,6 +3,7 @@ ro:
   articles:
     comment_counter:
       comments:
+        few: "%{count} comentarii"
         one: 1 comentariu
         other: "%{count} comentarii"
         zero: no comentarii

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3,6 +3,8 @@ ru:
   articles:
     comment_counter:
       comments:
+        few: 'Комментариев: %{count}'
+        many: 'Комментариев: %{count}'
         one: 1 комментарий
         other: 'Комментариев: %{count}'
         zero: Нет комментариев

--- a/publify_core/app/views/admin/content/_form.html.erb
+++ b/publify_core/app/views/admin/content/_form.html.erb
@@ -98,7 +98,7 @@
             </div>
             <div class="control-group">
               <p>
-                <%= t('.allowed_comments_html', allow_comment: content_tag(:strong, t('.allow_comments_status', count: @article.allow_comments ? 1 : 0))) %>
+                <%= t('.allowed_comments_html', allow_comment: content_tag(:strong, @article.allow_comments? ? t('.allow_comments_status.enabled') : t('.allow_comments_status.disabled'))) %>
                 <%= toggle_element('conversation') %>
               </p>
               <div id="conversation" class="collapse">

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -37,8 +37,8 @@ da:
       form:
         allow_comments: Tillad kommentarer
         allow_comments_status:
-          one: aktiveret
-          zero: disabled
+          disabled: disabled
+          enabled: aktiveret
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Anuller

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -6,7 +6,7 @@ de:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Don't lose the mail sent at %{email} or you won't be able to login anymore
-      login: Login
+      login: 'Login: %{login}'
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Create an account
@@ -37,8 +37,8 @@ de:
       form:
         allow_comments: Kommentare erlauben
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Abbrechen

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -37,8 +37,8 @@ en:
       form:
         allow_comments: Allow comments
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Cancel

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -6,7 +6,7 @@ es-MX:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: No pierda el correo enviado a %{email} o no podr&aacute; volver a acceder en el futuro
-      login: Login
+      login: 'Login: %{login}'
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Create an account
@@ -37,8 +37,8 @@ es-MX:
       form:
         allow_comments: Se permiten comentarios
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Cancelar

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -6,7 +6,7 @@ fr:
     confirm:
       admin: l'administration
       dont_lose_the_mail_sent: Ne perdez pas l'email que nous venons de vous envoyer à l'adresse %{email} ou vous ne pourrez plus vous connecter à l'application
-      login: Identifiant
+      login: 'Identifiant: %{login}'
       proceed_to: Allez sur %{link}
       success: You have successfully signed up.
     create_account: Créer un compte
@@ -37,8 +37,8 @@ fr:
       form:
         allow_comments: Autoriser les commentaires
         allow_comments_status:
-          one: activés
-          zero: désactivés
+          disabled: désactivés
+          enabled: activés
         allowed_comments_html: Les commentaires sont %{allow_comment}
         article_type: Type d'article
         cancel: Annuler

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -6,7 +6,7 @@ he:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Don't lose the mail sent at %{email} or you won't be able to login anymore
-      login: התחבר
+      login: "%{login} התחבר"
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Create an account
@@ -37,8 +37,8 @@ he:
       form:
         allow_comments: אפשר תגובות
         allow_comments_status:
-          one: מאופשר
-          zero: disabled
+          disabled: disabled
+          enabled: מאופשר
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: בטל
@@ -114,7 +114,7 @@ he:
           zero: אין כתבות
         comments_count:
           one: תגובה 1
-          other: "%d תגובות"
+          other: "%{count} תגובות"
           zero: אין תגובות
         content: תוכן
         drafts_count:
@@ -184,7 +184,7 @@ he:
         action_or_other_html: "%{first_action} או %{second_action}"
         author: Author
         cancel: Cancel
-        comments_for_html: תגובות עבור %s
+        comments_for_html: תגובות עבור %{article_link}
         edit_a_comment: Edit a comment
         email: Email
         save: שמור

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -37,8 +37,8 @@ it:
       form:
         allow_comments: Permetti commenti
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Annulla

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -6,7 +6,7 @@ ja:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Don't lose the mail sent at %{email} or you won't be able to login anymore
-      login: ログイン
+      login: 'ログイン: %{login}'
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Create an account
@@ -37,8 +37,8 @@ ja:
       form:
         allow_comments: コメントを許可
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: キャンセル

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -6,7 +6,7 @@ lt:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Don't lose the mail sent at %{email} or you won't be able to login anymore
-      login: Prisijungimas
+      login: 'Prisijungimas: %{login}'
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Create an account
@@ -37,8 +37,8 @@ lt:
       form:
         allow_comments: Leisti komentarus
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Baigti
@@ -104,43 +104,52 @@ lt:
         write_a_post: write a post
       welcome:
         approved_count:
+          few: "%{count} approved"
           one: 1 approved
           other: "%{count} approved"
           zero: no approved
         articles_and_comments_count_since: "%{articles_count} articles and %{comments_count} comments were posted since your last connexion"
         articles_count:
+          few: "%{count} articles"
           one: 1 article
           other: "%{count} articles"
           zero: no article
         comments_count:
+          few: "%{count} comments"
           one: 1 comment
           other: "%{count} comments"
           zero: nėra komentarų
         content: Content
         drafts_count:
+          few: "%{count} drafts"
           one: 1 draft
           other: "%{count} drafts"
           zero: no draft
         feedback: Atsiliepimas
         notes_count:
+          few: "%{count} notes"
           one: 1 note
           other: "%{count} notes"
           zero: no note
         pages_count:
+          few: "%{count} pages"
           one: 1 page
           other: "%{count} pages"
           zero: no page
         running_publify: You're running Publify %{version}
         spam_count:
+          few: "%{count} spam"
           one: 1 spam
           other: "%{count} spam"
           zero: no spam
         today: Today
         unconfirmed_count:
+          few: "%{count} unconfirmed"
           one: 1 unconfirmed
           other: "%{count} unconfirmed"
           zero: no unconfirmed
         your_articles_count:
+          few: "%{count} articles writen by you"
           one: 1 article writen by you
           other: "%{count} articles writen by you"
           zero: no article writen by you
@@ -163,10 +172,12 @@ lt:
         success_deleted: Deleted %{count} item(s)
         success_deleted_spam: All spam have been deleted
         success_mark_as_ham:
+          few: Marked %{count} items as Ham
           one: Marked 1 item as Ham
           other: Marked %{count} items as Ham
           zero: No item selected to mark as Ham
         success_mark_as_spam:
+          few: Marked %{count} items as Spam
           one: Marked 1 item as Spam
           other: Marked %{count} items as Spam
           zero: No item selected to mark as Spam
@@ -226,6 +237,7 @@ lt:
         information: Information
         may_take_a_moment: dauert einen Moment
         migration_pending:
+          few: There are %{count} migrations pending.
           one: There is one migration pending.
           other: There are %{count} migrations pending.
         migrations: Migrations
@@ -626,11 +638,13 @@ lt:
       continue_reading: Continue reading
     article_links:
       comments:
+        few: "%{count} Komentarai"
         one: 1 Komentaras
         other: "%{count} Komentarai"
         zero: no comments
       tags: Tags
       trackbacks:
+        few: "%{count} trackbacks"
         one: 1 trackback
         other: "%{count} trackbacks"
         zero: no trackbacks

--- a/publify_core/config/locales/nb-NO.yml
+++ b/publify_core/config/locales/nb-NO.yml
@@ -6,7 +6,7 @@ nb-NO:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Ikke mist eposten som ble sendt %{email}. Uten passordet vil du ikke kunne logge inn senere
-      login: Logg inn
+      login: 'Login: %{login}'
       proceed_to: Fortsett til %{link}
       success: You have successfully signed up.
     create_account: Opprett konto
@@ -37,8 +37,8 @@ nb-NO:
       form:
         allow_comments: Tillat kommentarer
         allow_comments_status:
-          one: aktivert
-          zero: deaktivert
+          disabled: deaktivert
+          enabled: aktivert
         allowed_comments_html: Kommentarer er %{allow_comment}
         article_type: Artikkeltype
         cancel: Avbryt

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -6,7 +6,7 @@ nl:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Verlies de e-mail verzonden naar %{email}, want anders kun je niet meer inloggen
-      login: inloggen
+      login: 'Login: %{login}'
       proceed_to: Ga door naar %{link}
       success: Je bent succesvol aangemeld.
     create_account: Maak een account aan
@@ -37,8 +37,8 @@ nl:
       form:
         allow_comments: Sta reacties toe
         allow_comments_status:
-          one: aangezet
-          zero: uitgezet
+          disabled: uitgezet
+          enabled: aangezet
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Terug
@@ -110,7 +110,7 @@ nl:
         articles_and_comments_count_since: "%{articles_count} artikels en %{comments_count} commentaren zijn geplaatst sinds je laatste bezoek"
         articles_count:
           one: 1 artikel
-          other: "%d artikelen"
+          other: "%{count} artikelen"
           zero: geen artikelen
         comments_count:
           one: 1 comment

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -37,8 +37,8 @@ pl:
       form:
         allow_comments: Zezwól na dodawanie komentarzy
         allow_comments_status:
-          one: włączone
-          zero: wyłączone
+          disabled: wyłączone
+          enabled: włączone
         allowed_comments_html: Komentarze są %{allow_comment}
         article_type: Typ artykułu
         cancel: Anuluj
@@ -104,43 +104,61 @@ pl:
         write_a_post: utworzyć wpis
       welcome:
         approved_count:
+          few: "%{count} zaakceptowane"
+          many: "%{count} zaakceptowane"
           one: 1 zaakceptowany
           other: "%{count} zaakceptowane"
           zero: brak zaakceptowanych
         articles_and_comments_count_since: "%{articles_count} artykułów i %{comments_count} komentarzy zostało opublikowanych od twojego ostaniego połączenia"
         articles_count:
+          few: "%{count} artykuły"
+          many: "%{count} artykuły"
           one: 1 artykuł
           other: "%{count} artykuły"
           zero: brak artykułów
         comments_count:
+          few: "%{count} komentarze"
+          many: "%{count} komentarze"
           one: 1 komentarz
           other: "%{count} komentarze"
           zero: brak komentarzy
         content: Treść
         drafts_count:
+          few: "%{count} szkice"
+          many: "%{count} szkice"
           one: 1 szkic
           other: "%{count} szkice"
           zero: brak szkiców
         feedback: Komentarze
         notes_count:
+          few: "%{count} notatki"
+          many: "%{count} notatki"
           one: 1 notatka
           other: "%{count} notatki"
           zero: brak notatek
         pages_count:
+          few: "%{count} strony"
+          many: "%{count} strony"
           one: 1 strona
           other: "%{count} strony"
           zero: brak stron
         running_publify: Działasz na Publify %{version}
         spam_count:
+          few: "%{count} spam"
+          many: "%{count} spam"
           one: 1 spam
           other: "%{count} spam"
           zero: brak spamu
         today: Dziś
         unconfirmed_count:
+          few: "%{count} niepotwierdzone"
+          many: "%{count} niepotwierdzone"
           one: 1 niepotwierdzony
           other: "%{count} niepotwierdzone"
           zero: brak niepotwierdzonych
         your_articles_count:
+          few: "%{count} artykuły napisane przez ciebie"
+          many: "%{count} artykuły napisane przez ciebie"
           one: 1 artykuł napisany przez ciebie
           other: "%{count} artykuły napisane przez ciebie"
           zero: brak artykułów napisanych przez ciebie
@@ -163,10 +181,14 @@ pl:
         success_deleted: Usunięto %{count} element(ów)
         success_deleted_spam: Cały spam został usunięty
         success_mark_as_ham:
+          few: Oznaczono %{count} elementów jako dopuszczone do publikacji
+          many: Oznaczono %{count} elementów jako dopuszczone do publikacji
           one: Oznacz 1 element jako dopuszczony do publikacji
           other: Oznaczono %{count} elementów jako dopuszczone do publikacji
           zero: Brak elementów oznaczonych jako dopusczone do publikacji
         success_mark_as_spam:
+          few: Oznaczono %{count} elementów jako spam
+          many: Oznaczono %{count} elementów jako spam
           one: Oznaczono 1 element jako spam
           other: Oznaczono %{count} elementów jako spam
           zero: Brak elementów oznaczonych jako spam
@@ -226,6 +248,8 @@ pl:
         information: Informacja
         may_take_a_moment: może zająć dłuższą chwilę
         migration_pending:
+          few: "%{count} oczekujących migracji."
+          many: "%{count} oczekujących migracji."
           one: Jedna oczekująca migracja.
           other: "%{count} oczekujących migracji."
         migrations: Migracje
@@ -626,11 +650,15 @@ pl:
       continue_reading: Continue reading
     article_links:
       comments:
+        few: "%{count} comments"
+        many: "%{count} comments"
         one: 1 comment
         other: "%{count} comments"
         zero: no comments
       tags: Tags
       trackbacks:
+        few: "%{count} trackbacks"
+        many: "%{count} trackbacks"
         one: 1 trackback
         other: "%{count} trackbacks"
         zero: no trackbacks

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -6,7 +6,7 @@ pt-BR:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Não perca o e-mail enviado para %{email} ou não será mais possível entrar no sistema
-      login: 'Entrar: %{user}'
+      login: 'Entrar: %{login}'
       proceed_to: Continuar para %{link}
       success: You have successfully signed up.
     create_account: Criar conta
@@ -37,8 +37,8 @@ pt-BR:
       form:
         allow_comments: Permitir comentários
         allow_comments_status:
-          one: habilitado
-          zero: desabilitado
+          disabled: desabilitado
+          enabled: habilitado
         allowed_comments_html: Comentários estão %{allow_comment}
         article_type: Tipo do Artigo
         cancel: Cancelar
@@ -94,7 +94,7 @@ pt-BR:
         welcome_back: Bem-vindo(a) novamente, %{user_name}!
       overview:
         change_your_blog_presentation: alterar a apresentação do seu blog
-        customization_explain_html: Você também pode aventurar-se como design, %{theme_link} ou %{sidebar_link.}
+        customization_explain_html: Você também pode aventurar-se como design, %{theme_link} ou %{sidebar_link}.
         dashboard_explain_html: Aqui você tem uma visão rápida sobre o que acontece no seu Publify e também o que você pode fazer. Talvez você queira %{available_actions}.
         enable_plugins: ativar plugins
         help_explain_html: Se precisar de alguma ajuda, %{doc_link}.

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -37,8 +37,8 @@ ro:
       form:
         allow_comments: Se permit comentarii
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Anulare
@@ -104,43 +104,52 @@ ro:
         write_a_post: write a post
       welcome:
         approved_count:
+          few: "%{count} approved"
           one: 1 approved
           other: "%{count} approved"
           zero: no approved
         articles_and_comments_count_since: "%{articles_count} articles and %{comments_count} comments were posted since your last connexion"
         articles_count:
+          few: "%{count} articles"
           one: 1 article
           other: "%{count} articles"
           zero: no article
         comments_count:
+          few: "%{count} comments"
           one: 1 comment
           other: "%{count} comments"
           zero: fără comentarii
         content: Content
         drafts_count:
+          few: "%{count} drafts"
           one: 1 draft
           other: "%{count} drafts"
           zero: no draft
         feedback: Feedback
         notes_count:
+          few: "%{count} notes"
           one: 1 note
           other: "%{count} notes"
           zero: no note
         pages_count:
+          few: "%{count} pages"
           one: 1 page
           other: "%{count} pages"
           zero: no page
         running_publify: You're running Publify %{version}
         spam_count:
+          few: "%{count} spam"
           one: 1 spam
           other: "%{count} spam"
           zero: no spam
         today: Today
         unconfirmed_count:
+          few: "%{count} unconfirmed"
           one: 1 unconfirmed
           other: "%{count} unconfirmed"
           zero: no unconfirmed
         your_articles_count:
+          few: "%{count} articles writen by you"
           one: 1 article writen by you
           other: "%{count} articles writen by you"
           zero: no article writen by you
@@ -163,10 +172,12 @@ ro:
         success_deleted: Deleted %{count} item(s)
         success_deleted_spam: All spam have been deleted
         success_mark_as_ham:
+          few: Marked %{count} items as Ham
           one: Marked 1 item as Ham
           other: Marked %{count} items as Ham
           zero: No item selected to mark as Ham
         success_mark_as_spam:
+          few: Marked %{count} items as Spam
           one: Marked 1 item as Spam
           other: Marked %{count} items as Spam
           zero: No item selected to mark as Spam
@@ -226,6 +237,7 @@ ro:
         information: Informații
         may_take_a_moment: ar putea să dureze puțin
         migration_pending:
+          few: There are %{count} migrations pending.
           one: There is one migration pending.
           other: There are %{count} migrations pending.
         migrations: Migrations
@@ -626,11 +638,13 @@ ro:
       continue_reading: Continue reading
     article_links:
       comments:
+        few: "%{count} comentarii"
         one: 1 comentariu
         other: "%{count} comentarii"
         zero: no comentarii
       tags: Tags
       trackbacks:
+        few: "%{count} trackbacks"
         one: 1 trackback
         other: "%{count} trackbacks"
         zero: no trackbacks

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -6,7 +6,7 @@ ru:
     confirm:
       admin: admin
       dont_lose_the_mail_sent: Не потеряйте письмо, высланное на %{email}, или вы больше не сможете зайти
-      login: 'логин: %{user}'
+      login: 'логин: %{login}'
       proceed_to: Proceed to %{link}
       success: You have successfully signed up.
     create_account: Создать учетную запись
@@ -37,8 +37,8 @@ ru:
       form:
         allow_comments: Разрешить комментарии
         allow_comments_status:
-          one: enabled
-          zero: выключены
+          disabled: выключены
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: Отменить
@@ -104,43 +104,61 @@ ru:
         write_a_post: написать пост
       welcome:
         approved_count:
+          few: "%{count} approved"
+          many: "%{count} approved"
           one: 1 approved
           other: "%{count} approved"
           zero: no approved
         articles_and_comments_count_since: "%{articles_count} постов и %{comments_count} комментариев получено с вашего последнего посещения"
         articles_count:
+          few: 'постов: %{count}'
+          many: 'постов: %{count}'
           one: 1 пост
           other: 'постов: %{count}'
           zero: нет постов
         comments_count:
+          few: 'комментариев: %{count}'
+          many: 'комментариев: %{count}'
           one: 1 комментарий
           other: 'комментариев: %{count}'
           zero: нет комментариев
         content: Content
         drafts_count:
+          few: 'черновиков: %{count}'
+          many: 'черновиков: %{count}'
           one: 1 черновик
           other: 'черновиков: %{count}'
           zero: нет черновиков
         feedback: Комментарии
         notes_count:
+          few: 'заметок: %{count}'
+          many: 'заметок: %{count}'
           one: 1 заметка
           other: 'заметок: %{count}'
           zero: нет заметок
         pages_count:
+          few: 'страниц: %{count}'
+          many: 'страниц: %{count}'
           one: 1 страница
           other: 'страниц: %{count}'
           zero: нет страниц
         running_publify: Работает Publify %{version}
         spam_count:
+          few: "%{count} spam"
+          many: "%{count} spam"
           one: 1 spam
           other: "%{count} spam"
           zero: no spam
         today: Сегодня
         unconfirmed_count:
+          few: "%{count} unconfirmed"
+          many: "%{count} unconfirmed"
           one: 1 unconfirmed
           other: "%{count} unconfirmed"
           zero: no unconfirmed
         your_articles_count:
+          few: 'постов написанных вами: %{count}'
+          many: 'постов написанных вами: %{count}'
           one: 1 пост написан вами
           other: 'постов написанных вами: %{count}'
           zero: нет постов написанных вами
@@ -163,10 +181,14 @@ ru:
         success_deleted: Deleted %{count} item(s)
         success_deleted_spam: All spam have been deleted
         success_mark_as_ham:
+          few: Marked %{count} items as Ham
+          many: Marked %{count} items as Ham
           one: Marked 1 item as Ham
           other: Marked %{count} items as Ham
           zero: No item selected to mark as Ham
         success_mark_as_spam:
+          few: Marked %{count} items as Spam
+          many: Marked %{count} items as Spam
           one: Marked 1 item as Spam
           other: Marked %{count} items as Spam
           zero: No item selected to mark as Spam
@@ -226,6 +248,8 @@ ru:
         information: Information
         may_take_a_moment: may take a moment
         migration_pending:
+          few: There are %{count} migrations pending.
+          many: There are %{count} migrations pending.
           one: There is one migration pending.
           other: There are %{count} migrations pending.
         migrations: Migrations
@@ -626,11 +650,15 @@ ru:
       continue_reading: Continue reading
     article_links:
       comments:
+        few: 'Комментариев: %{count}'
+        many: 'Комментариев: %{count}'
         one: 1 комментарий
         other: 'Комментариев: %{count}'
         zero: Нет комментариев
       tags: Tags
       trackbacks:
+        few: "%{count} trackbacks"
+        many: "%{count} trackbacks"
         one: 1 trackback
         other: "%{count} trackbacks"
         zero: no trackbacks

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -37,8 +37,8 @@ zh-CN:
       form:
         allow_comments: 允许评论
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: 取消

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -37,8 +37,8 @@ zh-TW:
       form:
         allow_comments: 允許評論
         allow_comments_status:
-          one: enabled
-          zero: disabled
+          disabled: disabled
+          enabled: enabled
         allowed_comments_html: Comments are %{allow_comment}
         article_type: Article type
         cancel: 取消

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'recaptcha', ['~> 4.3', '>= 4.3.1']
   s.add_dependency 'RedCloth', '~> 4.3.2'
   s.add_dependency 'rubypants', '~> 0.7.0'
-  s.add_dependency 'sassc-rails', '~> 1.3'
+  s.add_dependency 'sassc-rails', '~> 2.0'
   s.add_dependency 'twitter', '~> 6.2.0'
   s.add_dependency 'uuidtools', '~> 2.1.1'
 


### PR DESCRIPTION
* Update `pry`.
* Update `sassc-rails`. This means Publify no longer depends on the deprecated `sass` gem.
* Update `i18n-tasks` and fix new errors (inconsistent interpolations, missing pluralization keys).
* Pin `i18n-tasks` to avoid sudden build failures due to new checks being introduced.