### PR TITLE
Introduce Travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 cache: bundler
+
 rvm:
   - 2.4
   - 2.5
@@ -9,6 +10,15 @@ env:
   - DB=sqlite
   - DB=mysql
   - DB=postgresql
+
+jobs:
+  include:
+    - stage: lint
+      rvm: 2.6
+      before_script: []
+      script:
+        - bundle exec rake lint
+
 install:
   - cp config/database.yml.$DB config/database.yml
   - bundle install --without development

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ jobs:
       script:
         - bundle exec rake lint
 
-install:
-  - cp config/database.yml.$DB config/database.yml
-  - bundle install --without development
+bundler_args: --without development
 before_script:
+  - cp config/database.yml.$DB config/database.yml
   - bundle exec rake db:create db:migrate
 script:
   - bundle exec rake

--- a/lib/tasks/i18n.rake
+++ b/lib/tasks/i18n.rake
@@ -10,4 +10,4 @@ namespace :i18n do
   end
 end
 
-task default: "i18n:health"
+task lint: "i18n:health"

--- a/lib/tasks/manifests.rake
+++ b/lib/tasks/manifests.rake
@@ -15,6 +15,6 @@ task "publify_textfilter_code:manifest:check" do
   sh "cd publify_textfilter_code && rake manifest:check"
 end
 
-task default: "publify_core:manifest:check"
-task default: "publify_amazon_sidebar:manifest:check"
-task default: "publify_textfilter_code:manifest:check"
+task lint: "publify_core:manifest:check"
+task lint: "publify_amazon_sidebar:manifest:check"
+task lint: "publify_textfilter_code:manifest:check"


### PR DESCRIPTION
Should speed up the build by linting only once instead of 9 times.

Concretely:
* Move lint task to a separate build stage