### PR TITLE
Use new way to render Devise error messages in view override

### DIFF
--- a/publify_core/app/views/devise/registrations/new.html.erb
+++ b/publify_core/app/views/devise/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="form-group">
     <%= f.label :login %>


### PR DESCRIPTION
This silences a deprecation warning about `#devise_error_messages`.