### PR TITLE
Push engines into subrepos

### DIFF
--- a/publify_amazon_sidebar/.gitrepo
+++ b/publify_amazon_sidebar/.gitrepo
@@ -1,0 +1,11 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:publify/publify_amazon_sidebar.git
+	branch = master
+	commit = 
+	method = merge
+	cmdver = 0.4.0

--- a/publify_amazon_sidebar/.gitrepo
+++ b/publify_amazon_sidebar/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_amazon_sidebar.git
 	branch = master
-	commit = eda796d6e8f47be461920e923432f3da604a2f5a
+	commit = 9fa0ef39252506b55d068f39d2c3f920437fc5e0
 	method = merge
 	cmdver = 0.4.0
-	parent = 1957579d7938ccdd4cb9047ae2098b2d00572887
+	parent = 370192d277661003be8de4baead83cc4cf43552d

--- a/publify_amazon_sidebar/.gitrepo
+++ b/publify_amazon_sidebar/.gitrepo
@@ -6,6 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_amazon_sidebar.git
 	branch = master
-	commit = 
+	commit = eda796d6e8f47be461920e923432f3da604a2f5a
 	method = merge
 	cmdver = 0.4.0
+	parent = 1957579d7938ccdd4cb9047ae2098b2d00572887

--- a/publify_amazon_sidebar/Rakefile
+++ b/publify_amazon_sidebar/Rakefile
@@ -15,7 +15,7 @@ Bundler::GemHelper.install_tasks
 
 require "rspec/core/rake_task"
 
-desc "Run all specs in spec directory (excluding plugin specs)"
+desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(spec: "app:db:test:prepare")
 task default: :spec
 
@@ -41,7 +41,7 @@ namespace :manifest do
 
   desc "Check manifest"
   task :check do
-    abort "Manifest check failed" unless gemmable_files == manifest_files
+    raise "Manifest check failed, try recreating the manifest" unless gemmable_files == manifest_files
   end
 end
 task default: "manifest:check"

--- a/publify_amazon_sidebar/Rakefile
+++ b/publify_amazon_sidebar/Rakefile
@@ -24,7 +24,7 @@ namespace :manifest do
     `git ls-files -z`.split("\x0").reject do |file|
       file.match(%r{^(bin|spec)/}) ||
         file.match(%r{/\.keep$}) ||
-        %w(.gitignore .rspec Manifest.txt Rakefile publify_amazon_sidebar.gemspec).include?(file)
+        %w(.gitignore .gitrepo .rspec Manifest.txt Rakefile publify_amazon_sidebar.gemspec).include?(file)
     end
   end
 

--- a/publify_core/.gitrepo
+++ b/publify_core/.gitrepo
@@ -6,6 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_core.git
 	branch = master
-	commit = 
+	commit = 61872dab8cc9a0bc20f2238c29f87a4551dc352d
 	method = merge
 	cmdver = 0.4.0
+	parent = 11295996fe69bcfa90e8f9369a2586ac969f51b4

--- a/publify_core/.gitrepo
+++ b/publify_core/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_core.git
 	branch = master
-	commit = 61872dab8cc9a0bc20f2238c29f87a4551dc352d
+	commit = 9d698cd7eac432587a273a251841d292c21740ea
 	method = merge
 	cmdver = 0.4.0
-	parent = 11295996fe69bcfa90e8f9369a2586ac969f51b4
+	parent = 4da1dd191295d082a8726538fbde0f0e6b996da7

--- a/publify_core/.gitrepo
+++ b/publify_core/.gitrepo
@@ -1,0 +1,11 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:publify/publify_core.git
+	branch = master
+	commit = 
+	method = merge
+	cmdver = 0.4.0

--- a/publify_core/Rakefile
+++ b/publify_core/Rakefile
@@ -26,7 +26,7 @@ namespace :manifest do
     `git ls-files -z`.split("\x0").reject do |file|
       file.match(%r{^(bin|spec)/}) ||
         file.match(%r{/\.keep$}) ||
-        %w(.gitignore .rspec Manifest.txt Rakefile publify_core.gemspec).include?(file)
+        %w(.gitignore .gitrepo .rspec Manifest.txt Rakefile publify_core.gemspec).include?(file)
     end
   end
 

--- a/publify_textfilter_code/.gitrepo
+++ b/publify_textfilter_code/.gitrepo
@@ -6,6 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_textfilter_code.git
 	branch = master
-	commit = 
+	commit = f5e47ffd1712bd366ed9b70b7c50721d3fc4f616
 	method = merge
 	cmdver = 0.4.0
+	parent = 5cc09fddd03adae3385e66a6d5af3f43c84c5c10

--- a/publify_textfilter_code/.gitrepo
+++ b/publify_textfilter_code/.gitrepo
@@ -1,0 +1,11 @@
+; DO NOT EDIT (unless you know what you are doing)
+;
+; This subdirectory is a git "subrepo", and this file is maintained by the
+; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
+;
+[subrepo]
+	remote = git@github.com:publify/publify_textfilter_code.git
+	branch = master
+	commit = 
+	method = merge
+	cmdver = 0.4.0

--- a/publify_textfilter_code/.gitrepo
+++ b/publify_textfilter_code/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:publify/publify_textfilter_code.git
 	branch = master
-	commit = f5e47ffd1712bd366ed9b70b7c50721d3fc4f616
+	commit = 9d79ddf2fa3c02ad5cc18d55c1c551db37a0f2e2
 	method = merge
 	cmdver = 0.4.0
-	parent = 5cc09fddd03adae3385e66a6d5af3f43c84c5c10
+	parent = e0626a2b3aa2f9f62269784acdf8d94d908bf551

--- a/publify_textfilter_code/Rakefile
+++ b/publify_textfilter_code/Rakefile
@@ -25,7 +25,7 @@ namespace :manifest do
     `git ls-files -z`.split("\x0").reject do |file|
       file.match(%r{^(bin|spec)/}) ||
         file.match(%r{/\.keep$}) ||
-        %w(.gitignore .rspec Manifest.txt Rakefile publify_textfilter_code.gemspec).include?(file)
+        %w(.gitignore .gitrepo .rspec Manifest.txt Rakefile publify_textfilter_code.gemspec).include?(file)
     end
   end
 

--- a/publify_textfilter_code/Rakefile
+++ b/publify_textfilter_code/Rakefile
@@ -15,9 +15,8 @@ Bundler::GemHelper.install_tasks
 
 require "rspec/core/rake_task"
 
-desc "Run all specs in spec directory (excluding plugin specs)"
+desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(spec: "app:db:test:prepare")
-
 task default: :spec
 
 namespace :manifest do
@@ -42,7 +41,7 @@ namespace :manifest do
 
   desc "Check manifest"
   task :check do
-    abort "Manifest check failed" unless gemmable_files == manifest_files
+    raise "Manifest check failed, try recreating the manifest" unless gemmable_files == manifest_files
   end
 end
 task default: "manifest:check"


### PR DESCRIPTION
Uses [git-subrepo](https://github.com/ingydotnet/git-subrepo) to break out engines into their own repositories. From here on, development can occur either in the subrepos or this main repo.