### PR TITLE
Replace mimemagic with marcel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ["~> 6.0.3", ">= 6.0.3.5"]
+gem "rails", ["~> 6.0.3", ">= 6.0.3.6"]
 
 gem "mysql2"
 gem "pg"

--- a/publify_core/app/uploaders/resource_uploader.rb
+++ b/publify_core/app/uploaders/resource_uploader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mimemagic"
+require "marcel"
 
 class ResourceUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
@@ -50,14 +50,9 @@ class ResourceUploader < CarrierWave::Uploader::Base
     content_type = nil
 
     File.open(new_file.path) do |fd|
-      content_type = MimeMagic.by_magic(fd).try(:type)
+      content_type = Marcel::MimeType.for(fd)
     end
 
     content_type
-  end
-
-  # NOTE: This method was copied from MagicMimeBlacklist from CarrierWave 1.0.0.
-  def filemagic
-    @filemagic ||= FileMagic.new(FileMagic::MAGIC_MIME_TYPE)
   end
 end

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "akismet", "~> 3.0"
   s.add_dependency "bluecloth", "~> 2.1"
   s.add_dependency "cancancan", "~> 3.0"
-  s.add_dependency "carrierwave", "~> 2.0"
+  s.add_dependency "carrierwave", "~> 2.2.1"
   s.add_dependency "devise", "~> 4.7.1"
   s.add_dependency "devise-i18n", "~> 1.2"
   s.add_dependency "fog-aws", "~> 3.2"

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", "~> 4.4.0"
   s.add_dependency "jquery-ui-rails", "~> 6.0.1"
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]
-  s.add_dependency "mimemagic", "~> 0.3.2"
+  s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "mini_magick", ["~> 4.9", ">= 4.9.4"]
   s.add_dependency "rack", ">= 2.2.3"
   s.add_dependency "rails", "~> 6.0.0"


### PR DESCRIPTION
- Bump Rails version to one that includes transitive dependency on marcel 1.0.0
- Replace mimemagic dependency with dependency on marcel 1.0.0
- Update code that used MimeMagic to use Marcel::MimeType
- Remove old unused helper method