### PR TITLE
Update rubocop gems and fix new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem "pry", "~> 0.14.0"
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 5.0"
-  gem "rubocop", "~> 1.11.0", require: false
+  gem "rubocop", "~> 1.14.0", require: false
   gem "rubocop-performance", "~> 1.10.1", require: false
   gem "rubocop-rails", "~> 2.9.1", require: false
   gem "rubocop-rspec", "~> 2.2.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem "rubocop", "~> 1.14.0", require: false
   gem "rubocop-performance", "~> 1.11.3", require: false
   gem "rubocop-rails", "~> 2.10.1", require: false
-  gem "rubocop-rspec", "~> 2.2.0", require: false
+  gem "rubocop-rspec", "~> 2.3.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :development, :test do
   gem "rspec-rails", "~> 5.0"
   gem "rubocop", "~> 1.14.0", require: false
   gem "rubocop-performance", "~> 1.11.3", require: false
-  gem "rubocop-rails", "~> 2.9.1", require: false
+  gem "rubocop-rails", "~> 2.10.1", require: false
   gem "rubocop-rspec", "~> 2.2.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 5.0"
   gem "rubocop", "~> 1.14.0", require: false
-  gem "rubocop-performance", "~> 1.10.1", require: false
+  gem "rubocop-performance", "~> 1.11.3", require: false
   gem "rubocop-rails", "~> 2.9.1", require: false
   gem "rubocop-rspec", "~> 2.2.0", require: false
   gem "simplecov", "~> 0.21.2", require: false

--- a/lib/publify_textfilters.rb
+++ b/lib/publify_textfilters.rb
@@ -4,7 +4,7 @@ require "publify_plugins"
 require "text_filter_plugin"
 
 plugins_root = File.join(::Rails.root.to_s, "lib")
-separator = plugins_root.include?("/") ? "/" : '\\'
+separator = plugins_root.include?("/") ? "/" : "\\"
 
 Dir.glob(File.join(plugins_root, "*_textfilter_*")).select do |file|
   require file.split(separator).last.gsub(".rb", "")

--- a/publify_core/lib/sidebar_registry.rb
+++ b/publify_core/lib/sidebar_registry.rb
@@ -15,7 +15,7 @@ class SidebarRegistry
     end
 
     def register_sidebar_directory(plugins_root, paths)
-      separator = plugins_root.include?("/") ? "/" : '\\'
+      separator = plugins_root.include?("/") ? "/" : "\\"
 
       Dir.glob(File.join(plugins_root, "*_sidebar")).select do |file|
         plugin_name = file.split(separator).last

--- a/publify_core/spec/helpers/base_helper_spec.rb
+++ b/publify_core/spec/helpers/base_helper_spec.rb
@@ -121,25 +121,19 @@ RSpec.describe BaseHelper, type: :helper do
     end
 
     it "returns a link with the creation date and time" do
-      timezone = Time.zone
-      Time.zone = "UTC"
-
-      expect(get_reply_context_twitter_link(reply)).
-        to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-        "23/01/2014 at 13h47</a>"
-    ensure
-      Time.zone = timezone
+      Time.use_zone "UTC" do
+        expect(get_reply_context_twitter_link(reply)).
+          to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
+          "23/01/2014 at 13h47</a>"
+      end
     end
 
     it "displays creation date and time in the current time zone" do
-      timezone = Time.zone
-      Time.zone = "Tokyo"
-
-      expect(get_reply_context_twitter_link(reply)).
-        to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-        "23/01/2014 at 22h47</a>"
-    ensure
-      Time.zone = timezone
+      Time.use_zone "Tokyo" do
+        expect(get_reply_context_twitter_link(reply)).
+          to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
+          "23/01/2014 at 22h47</a>"
+      end
     end
   end
 

--- a/publify_core/spec/lib/publify_time_spec.rb
+++ b/publify_core/spec/lib/publify_time_spec.rb
@@ -73,18 +73,12 @@ end
 RSpec.describe "find Article date range " do
   let!(:blog) { create(:blog) }
 
-  before do
-    @timezone = Time.zone
-  end
-
-  after do
-    Time.zone = @timezone
-  end
-
   describe "UTC" do
-    before do
-      Time.zone = "UTC"
+    around do |example|
+      Time.use_zone("UTC", &example)
+    end
 
+    before do
       @a = build(:article)
       @a.published_at = "1 Jan 2013 01:00 UTC"
       @a.save!
@@ -127,9 +121,11 @@ RSpec.describe "find Article date range " do
   end
 
   describe "JST(+0900) " do
-    before do
-      Time.zone = "Tokyo"
+    around do |example|
+      Time.use_zone("Tokyo", &example)
+    end
 
+    before do
       @a = build(:article)
       @a.published_at = "1 Jan 2013 01:00 +0900"
       @a.save!

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -492,16 +492,14 @@ RSpec.describe Article, type: :model do
   end
 
   describe "an article published just before midnight UTC" do
+    around do |example|
+      Time.use_zone("UTC", &example)
+    end
+
     before do
-      @timezone = Time.zone
-      Time.zone = "UTC"
       @a = build(:article)
       @a.set_permalink
       @a.published_at = "21 Feb 2011 23:30 UTC"
-    end
-
-    after do
-      Time.zone = @timezone
     end
 
     describe "#permalink_url" do
@@ -521,16 +519,14 @@ RSpec.describe Article, type: :model do
   end
 
   describe "an article published just after midnight UTC" do
+    around do |example|
+      Time.use_zone("UTC", &example)
+    end
+
     before do
-      @timezone = Time.zone
-      Time.zone = "UTC"
       @a = build(:article)
       @a.set_permalink
       @a.published_at = "22 Feb 2011 00:30 UTC"
-    end
-
-    after do
-      Time.zone = @timezone
     end
 
     describe "#permalink_url" do
@@ -550,16 +546,14 @@ RSpec.describe Article, type: :model do
   end
 
   describe "an article published just before midnight JST (+0900)" do
+    around do |example|
+      Time.use_zone("Tokyo", &example)
+    end
+
     before do
-      @time_zone = Time.zone
-      Time.zone = "Tokyo"
       @a = build(:article)
       @a.set_permalink
       @a.published_at = "31 Dec 2012 23:30 +0900"
-    end
-
-    after do
-      Time.zone = @time_zone
     end
 
     describe "#permalink_url" do
@@ -579,16 +573,14 @@ RSpec.describe Article, type: :model do
   end
 
   describe "an article published just after midnight  JST (+0900)" do
+    around do |example|
+      Time.use_zone("Tokyo", &example)
+    end
+
     before do
-      @time_zone = Time.zone
-      Time.zone = "Tokyo"
       @a = build(:article)
       @a.set_permalink
       @a.published_at = "1 Jan 2013 00:30 +0900"
-    end
-
-    after do
-      Time.zone = @time_zone
     end
 
     describe "#permalink_url" do


### PR DESCRIPTION
- Update rubocop to version 1.14.0
- Update rubocop-performance to version 1.11.3
- Update rubocop-rails to version 2.10.1
- Update rubocop-rspec to version 2.3.0
- Autocorrect Style/StringLiterals
- Fix Rails/TimeZoneAssignment offenses
