### PR TITLE
Remove use of 'notextile'

### DIFF
--- a/publify_core/lib/publify_textfilter_markdown.rb
+++ b/publify_core/lib/publify_textfilter_markdown.rb
@@ -49,7 +49,7 @@ class PublifyApp
         # FIXME: Workaround for BlueCloth not interpreting <publify:foo> as an
         # HTML tag. See <http://deveiate.org/projects/BlueCloth/ticket/70>.
         escaped_macros = text.gsub(%r{(</?publify):}, '\1X')
-        html = BlueCloth.new(escaped_macros).to_html.gsub(%r{</?notextile>}, "")
+        html = BlueCloth.new(escaped_macros).to_html
         html.gsub(%r{(</?publify)X}, '\1:')
       end
     end

--- a/publify_textfilter_code/lib/publify_app/textfilter_code.rb
+++ b/publify_textfilter_code/lib/publify_app/textfilter_code.rb
@@ -57,7 +57,6 @@ PHP (&#42;), Python (&#42;), RHTML, Ruby, Scheme, SQL (&#42;), XHTML, XML, YAML.
         rescue
           text = HTMLEntities.new("xhtml1").encode(text)
         end
-        text = "<notextile>#{text}</notextile>"
 
         titlecode = if title
                       "<div class=\"codetitle\">#{title}</div>"

--- a/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
+++ b/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe "With the list of available filters", type: :model do
             result = filter_text("<publify:code>foo-code</publify:code>",
                                  [:macropre, :macropost])
             expect(result).
-              to eq '<div class="CodeRay"><pre><notextile>foo-code</notextile></pre></div>'
+              to eq '<div class="CodeRay"><pre>foo-code</pre></div>'
           end
 
           it "parses ruby lang" do
             result = filter_text('<publify:code lang="ruby">foo-code</publify:code>',
                                  [:macropre, :macropost])
             expect(result).
-              to eq('<div class="CodeRay"><pre><notextile><span class="CodeRay">' \
-                    "foo-code</span></notextile></pre></div>")
+              to eq('<div class="CodeRay"><pre><span class="CodeRay">' \
+                    "foo-code</span></pre></div>")
           end
 
           it "parses ruby and xml in same sentence but not in same place" do
@@ -32,10 +32,10 @@ RSpec.describe "With the list of available filters", type: :model do
                                    'blah blah <publify:code lang="xml">zzz</publify:code>',
                                  [:macropre, :macropost])
             expect(result).
-              to eq '<div class="CodeRay"><pre><notextile><span class="CodeRay">' \
-                    "foo-code</span></notextile></pre></div> blah blah" \
-                    ' <div class="CodeRay"><pre><notextile><span class="CodeRay">' \
-                    "zzz</span></notextile></pre></div>"
+              to eq '<div class="CodeRay"><pre><span class="CodeRay">' \
+                    "foo-code</span></pre></div> blah blah" \
+                    ' <div class="CodeRay"><pre><span class="CodeRay">' \
+                    "zzz</span></pre></div>"
           end
         end
 
@@ -52,11 +52,11 @@ RSpec.describe "With the list of available filters", type: :model do
             HTML
 
             expected_result = <<~HTML
-              <div class="CodeRay"><pre><notextile><span class="CodeRay"><span class="keyword">class</span> <span class="class">Foo</span>
+              <div class="CodeRay"><pre><span class="CodeRay"><span class="keyword">class</span> <span class="class">Foo</span>
                 <span class="keyword">def</span> <span class="function">bar</span>
                   <span class="instance-variable">@a</span> = <span class="string"><span class="delimiter">&quot;</span><span class="content">zzz</span><span class="delimiter">&quot;</span></span>
                 <span class="keyword">end</span>
-              <span class="keyword">end</span></span></notextile></pre></div>
+              <span class="keyword">end</span></span></pre></div>
             HTML
             expect(filter_text(original, [:macropre, :macropost])).to eq(expected_result)
           end


### PR DESCRIPTION
This removes the wrapping of code blocks in 'notextile' tags that was used to keep the textile filter from interpreting the code in the block as textile markup.

Fixes #811.
