### PR TITLE
Remove TextFilter.filter_text in favor of #filter_text

### DIFF
--- a/publify_core/app/controllers/admin/themes_controller.rb
+++ b/publify_core/app/controllers/admin/themes_controller.rb
@@ -9,8 +9,7 @@ class Admin::ThemesController < Admin::BaseController
     @themes = Theme.find_all
     @themes.each do |theme|
       # TODO: Move to Theme
-      theme.description_html = TextFilter.filter_text(theme.description,
-                                                      [:markdown, :smartypants])
+      theme.description_html = TextFilter.none.filter_text(theme.description)
     end
     @active = this_blog.current_theme
   end

--- a/publify_core/app/models/text_filter.rb
+++ b/publify_core/app/models/text_filter.rb
@@ -25,10 +25,11 @@ class TextFilter
     make_filter(name) || none
   end
 
-  def self.filter_text(text, filters)
+  def filter_text(text)
+    all_filters = [:macropre, markup, :macropost, filters].flatten
     map = TextFilterPlugin.filter_map
 
-    filters.each do |filter|
+    all_filters.each do |filter|
       next if filter.nil?
 
       filter_class = map[filter.to_s]
@@ -38,10 +39,6 @@ class TextFilter
     end
 
     text
-  end
-
-  def filter_text(text)
-    self.class.filter_text(text, [:macropre, markup, :macropost, filters].flatten)
   end
 
   def help

--- a/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
+++ b/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
@@ -3,39 +3,37 @@
 require "rails_helper"
 
 RSpec.describe PublifyApp::Textfilter::Twitterfilter do
-  def filter_text(text, filters)
-    TextFilter.filter_text(text, filters)
-  end
+  describe ".filtertext" do
+    it "replaces a hashtag with a proper URL to Twitter search" do
+      text = described_class.filtertext("A test tweet with a #hashtag")
+      expect(text).
+        to eq "A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
+        "&src=tren&mode=realtime'>#hashtag</a>"
+    end
 
-  it "replaces a hashtag with a proper URL to Twitter search" do
-    text = filter_text("A test tweet with a #hashtag", [:twitterfilter])
-    expect(text).
-      to eq "A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
-            "&src=tren&mode=realtime'>#hashtag</a>"
-  end
+    it "replaces a @mention by a proper URL to the twitter account" do
+      text = described_class.filtertext("A test tweet with a @mention")
+      expect(text).
+        to eq("A test tweet with a <a href='https://twitter.com/mention'>@mention</a>")
+    end
 
-  it "replaces a @mention by a proper URL to the twitter account" do
-    text = filter_text("A test tweet with a @mention", [:twitterfilter])
-    expect(text).
-      to eq("A test tweet with a <a href='https://twitter.com/mention'>@mention</a>")
-  end
+    it "replaces a http URL by a proper link" do
+      text = described_class.filtertext("A test tweet with a http://link.com")
+      expect(text).to eq("A test tweet with a <a href='http://link.com'>http://link.com</a>")
+    end
 
-  it "replaces a http URL by a proper link" do
-    text = filter_text("A test tweet with a http://link.com", [:twitterfilter])
-    expect(text).to eq("A test tweet with a <a href='http://link.com'>http://link.com</a>")
-  end
+    it "replaces a https URL with a proper link" do
+      text = described_class.filtertext("A test tweet with a https://link.com")
+      expect(text).
+        to eq("A test tweet with a <a href='https://link.com'>https://link.com</a>")
+    end
 
-  it "replaces a https URL with a proper link" do
-    text = filter_text("A test tweet with a https://link.com", [:twitterfilter])
-    expect(text).
-      to eq("A test tweet with a <a href='https://link.com'>https://link.com</a>")
-  end
-
-  it "works with a hashtag and a mention" do
-    text = filter_text("A test tweet with a #hashtag and a @mention", [:twitterfilter])
-    expect(text).
-      to eq("A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
-            "&src=tren&mode=realtime'>#hashtag</a> and a" \
-            " <a href='https://twitter.com/mention'>@mention</a>")
+    it "works with a hashtag and a mention" do
+      text = described_class.filtertext("A test tweet with a #hashtag and a @mention")
+      expect(text).
+        to eq("A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
+              "&src=tren&mode=realtime'>#hashtag</a> and a" \
+              " <a href='https://twitter.com/mention'>@mention</a>")
+    end
   end
 end

--- a/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
+++ b/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
@@ -5,32 +5,28 @@ require "publify_textfilter_markdown"
 
 RSpec.describe "With the list of available filters", type: :model do
   describe "#filter_text" do
-    def filter_text(text, filters)
-      TextFilter.filter_text(text, filters)
-    end
+    let(:filter) { TextFilter.none }
 
     describe "specific publify tags" do
       describe "code" do
         describe "single line" do
           it "mades nothin if no args" do
-            result = filter_text("<publify:code>foo-code</publify:code>",
-                                 [:macropre, :macropost])
+            result = filter.filter_text("<publify:code>foo-code</publify:code>")
             expect(result).
               to eq '<div class="CodeRay"><pre>foo-code</pre></div>'
           end
 
           it "parses ruby lang" do
-            result = filter_text('<publify:code lang="ruby">foo-code</publify:code>',
-                                 [:macropre, :macropost])
+            result = filter.filter_text('<publify:code lang="ruby">foo-code</publify:code>')
             expect(result).
               to eq('<div class="CodeRay"><pre><span class="CodeRay">' \
                     "foo-code</span></pre></div>")
           end
 
           it "parses ruby and xml in same sentence but not in same place" do
-            result = filter_text('<publify:code lang="ruby">foo-code</publify:code> ' \
-                                   'blah blah <publify:code lang="xml">zzz</publify:code>',
-                                 [:macropre, :macropost])
+            result = filter.
+              filter_text('<publify:code lang="ruby">foo-code</publify:code> ' \
+                          'blah blah <publify:code lang="xml">zzz</publify:code>')
             expect(result).
               to eq '<div class="CodeRay"><pre><span class="CodeRay">' \
                     "foo-code</span></pre></div> blah blah" \
@@ -58,7 +54,7 @@ RSpec.describe "With the list of available filters", type: :model do
                 <span class="keyword">end</span>
               <span class="keyword">end</span></span></pre></div>
             HTML
-            expect(filter_text(original, [:macropre, :macropost])).to eq(expected_result)
+            expect(filter.filter_text(original)).to eq(expected_result)
           end
         end
       end
@@ -93,8 +89,9 @@ RSpec.describe "With the list of available filters", type: :model do
         <p><em>footer text here</em></p>
       HTML
 
-      assert_equal expects_markdown.strip, filter_text(text,
-                                                       [:macropre, :markdown, :macropost])
+      filter = TextFilter.markdown
+
+      assert_equal expects_markdown.strip, filter.filter_text(text)
     end
   end
 end

--- a/spec/models/text_filter_spec.rb
+++ b/spec/models/text_filter_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "With the list of available filters", type: :model do
-  let(:blog) { build_stubbed(:blog) }
   let(:flickr_photos) { double "flickr_photos" }
   let(:flickr_photo_info_url) do
     double("flickr_photo_info_url",
@@ -71,132 +70,124 @@ RSpec.describe "With the list of available filters", type: :model do
   end
 
   describe "#filter_text" do
-    def filter_text(text, filters)
-      TextFilter.filter_text(text, filters)
+    it "works for markdown" do
+      filter = TextFilter.markdown
+      expect(filter.filter_text('*"foo"*')).to eq "<p><em>\"foo\"</em></p>"
     end
 
-    it "unknown" do
-      text = filter_text("*foo*", [:unknowndoesnotexist])
-      expect(text).to eq("*foo*")
+    it "works for markdown with smart quotes" do
+      filter = TextFilter.markdown_smartypants
+      expect(filter.filter_text('*"foo"*')).to eq "<p><em>&#8220;foo&#8221;</em></p>"
     end
 
-    it "filterchain" do
-      assert_equal "<p><em>&#8220;foo&#8221;</em></p>",
-                   filter_text('*"foo"*', [:markdown, :smartypants])
-
-      assert_equal "<p><em>&#8220;foo&#8221;</em></p>",
-                   filter_text('*"foo"*',
-                               [:doesntexist1, :markdown, "doesn't exist 2",
-                                :smartypants, :nopenotmeeither])
+    it "works for smart quotes" do
+      filter = TextFilter.smartypants
+      expect(filter.filter_text('I am "smart"')).to eq "I am &#8220;smart&#8221;"
     end
 
-    describe "specific publify tags" do
-      describe "flickr" do
-        it "shows with default settings" do
-          result =
-            filter_text('<publify:flickr img="31366117" size="Square" style="float:left"/>',
-                        [:macropre, :macropost])
-          expect(result).to eq \
-            '<div style="float:left" class="flickrplugin">' \
-            '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-            "Ruby's creator</p></div>"
-        end
+    context "when using the flickr macro with a plain filter" do
+      let(:filter) { TextFilter.none }
 
-        it "uses default image size" do
-          result = filter_text('<publify:flickr img="31366117"/>', [:macropre, :macropost])
-          expect(result).to eq \
-            '<div style="" class="flickrplugin">' \
-            '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-            "Ruby's creator</p></div>"
-        end
-
-        it "uses caption" do
-          result = filter_text('<publify:flickr img="31366117" caption=""/>',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            '<div style="" class="flickrplugin">' \
-            '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a></div>'
-        end
-
-        it "broken_flickr_link" do
-          result = filter_text('<publify:flickr img="notaflickrid" />',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            "<div class='broken_flickr_link'>" \
-            "`notaflickrid' could not be displayed because: <br />" \
-            "Photo not found</div>"
-        end
+      it "shows with default settings" do
+        result = filter.
+          filter_text('<publify:flickr img="31366117" size="Square" style="float:left"/>')
+        expect(result).to eq \
+          '<div style="float:left" class="flickrplugin">' \
+          '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
+          "Ruby's creator</p></div>"
       end
 
-      describe "lightbox" do
-        it "works" do
-          result = filter_text('<publify:lightbox img="31366117" thumbsize="Thumbnail"' \
-                               ' displaysize="Large" style="float:left"/>',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            '<a href="//photos23.flickr.com/31366117_b1a791d68e_b.jpg"' \
-            ' data-toggle="lightbox" title="Matz">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_t.jpg"' \
-            ' width="67" height="100" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:67px\">This is Matz, Ruby's creator</p>"
-        end
+      it "uses default image size" do
+        result = filter.filter_text('<publify:flickr img="31366117"/>')
+        expect(result).to eq \
+          '<div style="" class="flickrplugin">' \
+          '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
+          "Ruby's creator</p></div>"
+      end
 
-        it "uses default thumb image size" do
-          result = filter_text('<publify:lightbox img="31366117" displaysize="Large"/>',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            '<a href="//photos23.flickr.com/31366117_b1a791d68e_b.jpg"' \
-            ' data-toggle="lightbox" title="Matz">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:75px\">This is Matz, Ruby's creator</p>"
-        end
+      it "uses caption" do
+        result = filter.filter_text('<publify:flickr img="31366117" caption=""/>')
+        expect(result).to eq \
+          '<div style="" class="flickrplugin">' \
+          '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a></div>'
+      end
 
-        it "uses default display image size" do
-          result = filter_text('<publify:lightbox img="31366117"/>',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            '<a href="//photos23.flickr.com/31366117_b1a791d68e_o.jpg"' \
-            ' data-toggle="lightbox" title="Matz">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:75px\">This is Matz, Ruby's creator</p>"
-        end
-
-        it "works with caption" do
-          result = filter_text('<publify:lightbox img="31366117" caption=""/>',
-                               [:macropre, :macropost])
-          expect(result).to eq \
-            '<a href="//photos23.flickr.com/31366117_b1a791d68e_o.jpg"' \
-            ' data-toggle="lightbox" title="Matz">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>'
-        end
+      it "broken_flickr_link" do
+        result = filter.filter_text('<publify:flickr img="notaflickrid" />')
+        expect(result).to eq \
+          "<div class='broken_flickr_link'>" \
+          "`notaflickrid' could not be displayed because: <br />" \
+          "Photo not found</div>"
       end
     end
 
-    describe "combining a post-macro" do
-      describe "with markdown" do
-        it "correctly interprets the macro" do
-          result =
-            filter_text('<publify:flickr img="31366117" size="Square" style="float:left"/>',
-                        [:macropre, :markdown, :macropost])
-          expect(result).to eq \
-            '<p><div style="float:left" class="flickrplugin">' \
-            '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
-            '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
-            ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-            "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-            "Ruby's creator</p></div></p>"
-        end
+    context "when using the lightbox macro" do
+      let(:filter) { TextFilter.none }
+
+      it "works" do
+        result = filter.
+          filter_text('<publify:lightbox img="31366117" thumbsize="Thumbnail"' \
+                      ' displaysize="Large" style="float:left"/>')
+        expect(result).to eq \
+          '<a href="//photos23.flickr.com/31366117_b1a791d68e_b.jpg"' \
+          ' data-toggle="lightbox" title="Matz">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_t.jpg"' \
+          ' width="67" height="100" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:67px\">This is Matz, Ruby's creator</p>"
+      end
+
+      it "uses default thumb image size" do
+        result = filter.
+          filter_text('<publify:lightbox img="31366117" displaysize="Large"/>')
+        expect(result).to eq \
+          '<a href="//photos23.flickr.com/31366117_b1a791d68e_b.jpg"' \
+          ' data-toggle="lightbox" title="Matz">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:75px\">This is Matz, Ruby's creator</p>"
+      end
+
+      it "uses default display image size" do
+        result = filter.filter_text('<publify:lightbox img="31366117"/>')
+        expect(result).to eq \
+          '<a href="//photos23.flickr.com/31366117_b1a791d68e_o.jpg"' \
+          ' data-toggle="lightbox" title="Matz">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:75px\">This is Matz, Ruby's creator</p>"
+      end
+
+      it "works with caption" do
+        result = filter.filter_text('<publify:lightbox img="31366117" caption=""/>')
+        expect(result).to eq \
+          '<a href="//photos23.flickr.com/31366117_b1a791d68e_o.jpg"' \
+          ' data-toggle="lightbox" title="Matz">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>'
+      end
+    end
+
+    context "when combining a post-macro with markdown" do
+      let(:filter) { TextFilter.markdown }
+
+      it "correctly interprets the macro" do
+        result = filter.
+          filter_text('<publify:flickr img="31366117" size="Square" style="float:left"/>')
+        expect(result).to eq \
+          '<p><div style="float:left" class="flickrplugin">' \
+          '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
+          '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
+          ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
+          "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
+          "Ruby's creator</p></div></p>"
       end
     end
   end


### PR DESCRIPTION
This makes the translation from TextFilter instance to a set of TextFilterPlugin classes internal to the TextFilter class, allowing more flexibility.
