### PR TITLE
Improve feedback listings

### DIFF
--- a/publify_core/app/views/admin/feedback/article.html.erb
+++ b/publify_core/app/views/admin/feedback/article.html.erb
@@ -1,24 +1,31 @@
 <% content_for :page_heading do %>
-<h2 class="page-title">
-  <%= t('.comments_for_html', title: @article.title) %>
-</h2>
+  <h2 class="page-title">
+    <%= t('.comments_for_html', title: @article.title) %>
+  </h2>
 <% end %>
 
 <%= form_tag({ action: 'bulkops' }, { class: 'form-inline' }) do %>
 
   <%= hidden_field 'article_id', @article.id %>
-  <%= render 'button', position: 'top' %>
 
-  <br class='clear' />
+  <% if @feedback.any? %>
+    <%= render 'button', position: 'top' %>
+  <% end %>
+
   <table class='table hover'>
     <thead>
       <tr class='noborder'>
-        <th colspan='5'>
+        <th>
           <input type="checkbox" name="checkall" id="checkall" onclick="check_all(this);" />
-          <%= t('.select_all') %>
         </th>
+        <th><%= t(".author") %></th>
+        <th><%= t(".created_at") %></th>
+        <th><%= t(".status") %></th>
+        <th><%= t(".content") %></th>
+        <th><%= t(".actions") %></th>
       </tr>
     </thead>
+
     <% if @feedback.empty? %>
       <tr>
         <td colspan="5">
@@ -61,7 +68,7 @@
         <%= text_area 'comment', 'body', rows: '10', class: 'form-control' %>
       </div>
     </div>
-    <div class='form-group col-md-12'>
+    <div>
       <%= t('.action_or_other_html', first_action: link_to(t('.cancel'), action: 'index'), second_action: submit_tag(t('.save'), class: 'btn btn-primary')) %>
     </div>
   </fieldset>

--- a/publify_core/app/views/admin/feedback/index.html.erb
+++ b/publify_core/app/views/admin/feedback/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_heading do %>
-  <h2>
+  <h2 class="page-title">
     <%= t('.feedback') %>
   </h2>
 <% end %>
@@ -19,7 +19,10 @@
 
   <%= hidden_field_tag 'page', params[:page] %>
 
-  <%= render 'button', position: 'top' %>
+  <% if @feedback.any? %>
+    <%= render 'button', position: 'top' %>
+  <% end %>
+
   <table class='table hover'>
     <thead>
       <tr class='noborder'>
@@ -33,6 +36,7 @@
         <th><%= t(".actions") %></th>
       </tr>
     </thead>
+
     <% if @feedback.empty? %>
       <tr>
         <td colspan="5">
@@ -40,16 +44,12 @@
         </td>
       </tr>
     <% end %>
+
     <% @feedback.each do |comment| %>
       <%= render 'feedback', comment: comment %>
     <% end %>
     <%= display_pagination(@feedback, 7) %>
-    <tr>
-      <th><input type="checkbox" name="checkall" id="checkall" onclick="check_all(this);" /></th>
-      <th colspan='6'><%= t('.select_all') %></th>
-    </tr>
   </table>
-  <%= render 'button', position: 'bottom' %>
 <% end %>
 
 <br class='clear' />

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -152,14 +152,17 @@ da:
     feedback:
       article:
         action_or_other_html: "%{first_action} eller %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Forfatter
         cancel: Anuller
         comments_for_html: Kommentarer for %{title}
+        content: Indhold
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Gem
-        select_all: Select all
+        status: Status
         url: Url
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ da:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Status
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -152,14 +152,17 @@ de:
     feedback:
       article:
         action_or_other_html: "%{first_action} oder %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Autor
         cancel: Abbrechen
         comments_for_html: Kommentare für %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Speichern
-        select_all: Select all
+        status: Status
         url: Url
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ de:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Status
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -152,14 +152,17 @@ en:
     feedback:
       article:
         action_or_other_html: "%{first_action} or %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Author
         cancel: Cancel
         comments_for_html: Comments for %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Save
-        select_all: Select all
+        status: Status
         url: Url
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ en:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Status
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -152,14 +152,17 @@ es-MX:
     feedback:
       article:
         action_or_other_html: "%{first_action} o %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Autor
         cancel: Cancelar
         comments_for_html: Comentarios para %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Guardar
-        select_all: Select all
+        status: Estado
         url: Url
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ es-MX:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Estado
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -154,15 +154,18 @@ fr:
     feedback:
       article:
         action_or_other_html: "%{first_action} ou %{second_action}"
+        actions: Actions
         add_a_comment: Ajouter un commentaire
         author: Auteur
         cancel: Annuler
         comments_for_html: Commentaire sur %{title}
+        content: Contenu
+        created_at: Created at
         email: Email
         no_feedback: 'Il n''y a pas encore de commentaires, pourquoi ne pas en créer
           un ? '
         save: Sauver
-        select_all: Tout sélectionner
+        status: État
         url: Site
         your_comment: Votre commentaire
       bulkops:
@@ -210,7 +213,6 @@ fr:
           un ? '
         presumed_ham: Probablement valide
         presumed_spam: Probablement du spam
-        select_all: Tout sélectionner
         spam: Spam
         status: État
         unapproved_comments: Commentaires non validés

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -151,14 +151,17 @@ he:
     feedback:
       article:
         action_or_other_html: "%{first_action} או %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: כותב
         cancel: בטל
         comments_for_html: תגובות עבור %{title}
+        content: תוכן
+        created_at: Created at
         email: דואל
         no_feedback: There is no feedback yet. Why don't you create some?
         save: שמור
-        select_all: Select all
+        status: מצב
         url: כתובת
         your_comment: Your comment
       bulkops:
@@ -205,7 +208,6 @@ he:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: ספאם
         status: מצב
         unapproved_comments: תגובות לא מאושרות

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -152,14 +152,17 @@ it:
     feedback:
       article:
         action_or_other_html: "%{first_action} o %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Autore
         cancel: Annulla
         comments_for_html: Commenti per %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Salva
-        select_all: Select all
+        status: Stato
         url: Sito
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ it:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Stato
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -151,14 +151,17 @@ ja:
     feedback:
       article:
         action_or_other_html: "%{first_action} または %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: 投稿者
         cancel: キャンセル
         comments_for_html: "〜へコメント%{title}"
+        content: コンテンツ
+        created_at: Created at
         email: メールアドレス
-        no_feedback: There are no feedback yet. Why don't you start and create one?
+        no_feedback: There is no feedback yet. Why don't you create some?
         save: 保存
-        select_all: Select all
+        status: ステータス
         url: Url
         your_comment: Your comment
       bulkops:
@@ -205,7 +208,6 @@ ja:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: スパム
         status: ステータス
         unapproved_comments: 未承認コメント

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -161,14 +161,17 @@ lt:
     feedback:
       article:
         action_or_other_html: "%{first_action} arba %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Autorius
         cancel: Baigti
         comments_for_html: Komentarai %{title}
+        content: Content
+        created_at: Created at
         email: El. pašto adresas
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Saugoti
-        select_all: Select all
+        status: Statusas
         url: Url adresas
         your_comment: Your comment
       bulkops:
@@ -217,7 +220,6 @@ lt:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Statusas
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/nb.yml
+++ b/publify_core/config/locales/nb.yml
@@ -152,14 +152,17 @@ nb:
     feedback:
       article:
         action_or_other_html: "%{first_action} eller %{second_action}"
+        actions: Actions
         add_a_comment: Legg til kommentar
         author: Forfatter
         cancel: Avbryt
         comments_for_html: Kommentarer for %{title}
+        content: Innhold
+        created_at: Created at
         email: Epost
         no_feedback: Det finnes ingen diskusjon enda. Hva med å opprette en?
         save: Lagre
-        select_all: Velg alle
+        status: Status
         url: URL
         your_comment: Din kommentar
       bulkops:
@@ -206,7 +209,6 @@ nb:
         no_feedback: Det finnes ingen diskusjon enda. Hva med å opprette en?
         presumed_ham: Antatt ikke-spam
         presumed_spam: Antall spam
-        select_all: Velg alle
         spam: Spam
         status: Status
         unapproved_comments: Kommentarer på vent

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -152,14 +152,17 @@ nl:
     feedback:
       article:
         action_or_other_html: "%{first_action} of %{second_action}"
+        actions: Actions
         add_a_comment: Voeg een commentaar toe
         author: Auteur
         cancel: Terug
         comments_for_html: Commentaren voor %{title}
+        content: Inhoud
+        created_at: Created at
         email: e-mail
-        no_feedback: Er zijn nog geen feedback. Waarom begin je er niet een te maken?
+        no_feedback: Er zijn nog geen reacties. Waarom maak je er geen?
         save: Opslaan
-        select_all: Select all
+        status: Status
         url: Url
         your_comment: Your comment
       bulkops:
@@ -206,7 +209,6 @@ nl:
         no_feedback: Er zijn nog geen reacties. Waarom maak je er geen?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Status
         unapproved_comments: Niet goedgekeurde reacties

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -170,14 +170,17 @@ pl:
     feedback:
       article:
         action_or_other_html: "%{first_action} lub %{second_action}"
+        actions: Actions
         add_a_comment: Dodaj komentarz
         author: Autor
         cancel: Anuluj
         comments_for_html: Komentarze do %{title}
+        content: Treść
+        created_at: Created at
         email: Email
         no_feedback: Brak komentarzy.
         save: Zapisz
-        select_all: Wybierz wszystko
+        status: Stan
         url: Url
         your_comment: Twój komentarz
       bulkops:
@@ -228,7 +231,6 @@ pl:
         no_feedback: Brak komentarzy.
         presumed_ham: Prawdopodobny nie-spam
         presumed_spam: Prawdopodobny spam
-        select_all: Zaznacz wszystko
         spam: Spam
         status: Stan
         unapproved_comments: Niezaakceptowane komentarze

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -152,14 +152,17 @@ pt-BR:
     feedback:
       article:
         action_or_other_html: "%{first_action} ou %{second_action}"
+        actions: Actions
         add_a_comment: Adicionar um comentário
         author: Autor
         cancel: Cancelar
         comments_for_html: Comentários para %{title}
+        content: Conteúdo
+        created_at: Created at
         email: E-mail
         no_feedback: Não existem feedback ainda. Por que você não inicia e cria um?
         save: Salvar
-        select_all: Selecionar todos
+        status: Estado
         url: Url
         your_comment: Seu comentário
       bulkops:
@@ -206,7 +209,6 @@ pt-BR:
         no_feedback: Não existem feedback ainda. Por que você não inicia e cria um?
         presumed_ham: Possível ham
         presumed_spam: Possível spam
-        select_all: Selecionar todos
         spam: Spam
         status: Estado
         unapproved_comments: Comentários não aprovados

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -161,14 +161,17 @@ ro:
     feedback:
       article:
         action_or_other_html: "%{first_action} sau %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: Autor
         cancel: Anulare
         comments_for_html: Comentariile la %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: Salvează
-        select_all: Select all
+        status: Status
         url: Adresa
         your_comment: Your comment
       bulkops:
@@ -217,7 +220,6 @@ ro:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: Status
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -170,14 +170,17 @@ ru:
     feedback:
       article:
         action_or_other_html: "%{first_action} или %{second_action}"
+        actions: Actions
         add_a_comment: Добавить комментарий
         author: Автор
         cancel: Отменить
         comments_for_html: Комментарии к %{title}
+        content: Content
+        created_at: Created at
         email: Email
-        no_feedback: Пока нет комментариев.
+        no_feedback: Ничего нет. Почему бы не начать и не добавить?
         save: Сохранить
-        select_all: Выбрать все
+        status: Статус
         url: Url
         your_comment: Ваш комментарий
       bulkops:
@@ -228,7 +231,6 @@ ru:
         no_feedback: Ничего нет. Почему бы не начать и не добавить?
         presumed_ham: Предположительно хорошие
         presumed_spam: Предположительно спам
-        select_all: Выбрать все
         spam: Спам
         status: Статус
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -148,14 +148,17 @@ zh-CN:
     feedback:
       article:
         action_or_other_html: "%{first_action} 或 %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: 作者
         cancel: 取消
         comments_for_html: 做出评论 %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: 这儿并不存在Feedback。让我们开始创建它。
         save: 保存
-        select_all: Select all
+        status: 状态
         url: Url
         your_comment: Your comment
       bulkops:
@@ -202,7 +205,6 @@ zh-CN:
         no_feedback: 这儿并不存在Feedback。让我们开始创建它。
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: 状态
         unapproved_comments: Unapproved comments

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -149,14 +149,17 @@ zh-TW:
     feedback:
       article:
         action_or_other_html: "%{first_action} 或 %{second_action}"
+        actions: Actions
         add_a_comment: Add a comment
         author: 作者
         cancel: 取消
         comments_for_html: 做出評論 %{title}
+        content: Content
+        created_at: Created at
         email: Email
         no_feedback: There is no feedback yet. Why don't you create some?
         save: 存檔
-        select_all: Select all
+        status: 身分
         url: Url
         your_comment: Your comment
       bulkops:
@@ -203,7 +206,6 @@ zh-TW:
         no_feedback: There is no feedback yet. Why don't you create some?
         presumed_ham: Presumed ham
         presumed_spam: Presumed spam
-        select_all: Select all
         spam: Spam
         status: 身分
         unapproved_comments: Unapproved comments


### PR DESCRIPTION
- Hide bulk ops when not relevant
- Unify table headings
- Show bulk ops and select-all check only once in main feedback index page
