### PR TITLE
Handle markdown links in notes correctly

### DIFF
--- a/publify_core/app/models/content_base.rb
+++ b/publify_core/app/models/content_base.rb
@@ -34,18 +34,13 @@ module ContentBase
   # object.
   def generate_html(field, text = nil)
     text ||= self[field].to_s
-    prehtml = html_preprocess(field, text).to_s
-    html = (text_filter || default_text_filter).filter_text(prehtml) || prehtml
+    html = (text_filter || default_text_filter).filter_text(text) || text
     html_postprocess(field, html).to_s
   end
 
   # Post-process the HTML.  This is a noop by default, but Comment overrides it
   # to enforce HTML sanity.
   def html_postprocess(_field, html)
-    html
-  end
-
-  def html_preprocess(_field, html)
     html
   end
 

--- a/publify_core/app/models/note.rb
+++ b/publify_core/app/models/note.rb
@@ -43,7 +43,7 @@ class Note < Content
     []
   end
 
-  def html_preprocess(_field, html)
+  def html_postprocess(_field, html)
     PublifyApp::Textfilter::Twitterfilter.filtertext(html)
   end
 

--- a/publify_core/lib/publify_textfilter_twitterfilter.rb
+++ b/publify_core/lib/publify_textfilter_twitterfilter.rb
@@ -10,10 +10,8 @@ class PublifyApp
 
       def self.filtertext(text)
         # First, autolink
-        text = text.to_s
-        URI.extract(text, %w(http https mailto gopher)) do |item|
-          text = text.gsub(item, "<a href='#{item}'>#{item}</a>")
-        end
+        helper = Feedback::ContentTextHelpers.new
+        text = helper.auto_link(text)
 
         # hashtags
         text.split.grep(/^#\w+/) do |item|

--- a/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
+++ b/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe PublifyApp::Textfilter::Twitterfilter do
 
     it "replaces a http URL by a proper link" do
       text = described_class.filtertext("A test tweet with a http://link.com")
-      expect(text).to eq("A test tweet with a <a href='http://link.com'>http://link.com</a>")
+      expect(text).to eq("A test tweet with a <a href=\"http://link.com\">http://link.com</a>")
     end
 
     it "replaces a https URL with a proper link" do
       text = described_class.filtertext("A test tweet with a https://link.com")
       expect(text).
-        to eq("A test tweet with a <a href='https://link.com'>https://link.com</a>")
+        to eq("A test tweet with a <a href=\"https://link.com\">https://link.com</a>")
     end
 
     it "works with a hashtag and a mention" do

--- a/publify_core/spec/models/note_spec.rb
+++ b/publify_core/spec/models/note_spec.rb
@@ -260,31 +260,31 @@ RSpec.describe Note, type: :model do
   context "with a dofollowify blog" do
     let!(:blog) { create(:blog, dofollowify: true) }
 
-    describe "Testing hashtag and @mention replacement in html postprocessing" do
+    describe "Testing hashtag and @mention replacement" do
       it "replaces a hashtag with a proper URL to Twitter search" do
         note = build(:note, body: "A test tweet with a #hashtag")
         expected =
-          "A test tweet with a <a href='https://twitter.com/search?q=%23hashtag&" \
-          "src=tren&mode=realtime'>#hashtag</a>"
-        expect(note.html_preprocess(nil, note.body)).to eq(expected)
+          "<p>A test tweet with a <a href='https://twitter.com/search?q=%23hashtag&" \
+          "src=tren&mode=realtime'>#hashtag</a></p>"
+        expect(note.html).to eq(expected)
       end
 
       it "replaces a @mention by a proper URL to the twitter account" do
         note = create(:note, body: "A test tweet with a @mention")
-        expected = "A test tweet with a <a href='https://twitter.com/mention'>@mention</a>"
-        expect(note.html_preprocess(nil, note.body)).to eq(expected)
+        expected = "<p>A test tweet with a <a href='https://twitter.com/mention'>@mention</a></p>"
+        expect(note.html).to eq(expected)
       end
 
       it "replaces a http URL by a proper link" do
         note = create(:note, body: "A test tweet with a http://link.com")
-        expected = "A test tweet with a <a href='http://link.com'>http://link.com</a>"
-        expect(note.html_preprocess(nil, note.body)).to eq(expected)
+        expected = "<p>A test tweet with a <a href='http://link.com'>http://link.com</a></p>"
+        expect(note.html).to eq(expected)
       end
 
       it "replaces a https URL with a proper link" do
         note = create(:note, body: "A test tweet with a https://link.com")
-        expected = "A test tweet with a <a href='https://link.com'>https://link.com</a>"
-        expect(note.html_preprocess(nil, note.body)).to eq(expected)
+        expected = "<p>A test tweet with a <a href='https://link.com'>https://link.com</a></p>"
+        expect(note.html).to eq(expected)
       end
     end
   end

--- a/publify_core/spec/models/note_spec.rb
+++ b/publify_core/spec/models/note_spec.rb
@@ -277,14 +277,20 @@ RSpec.describe Note, type: :model do
 
       it "replaces a http URL by a proper link" do
         note = create(:note, body: "A test tweet with a http://link.com")
-        expected = "<p>A test tweet with a <a href='http://link.com'>http://link.com</a></p>"
+        expected = "<p>A test tweet with a <a href=\"http://link.com\">http://link.com</a></p>"
         expect(note.html).to eq(expected)
       end
 
       it "replaces a https URL with a proper link" do
         note = create(:note, body: "A test tweet with a https://link.com")
-        expected = "<p>A test tweet with a <a href='https://link.com'>https://link.com</a></p>"
+        expected = "<p>A test tweet with a <a href=\"https://link.com\">https://link.com</a></p>"
         expect(note.html).to eq(expected)
+      end
+
+      it "links markdown links only once" do
+        note = create(:note, body: "A test tweet with [a markdown link](https://link.com)")
+        expect(note.html).
+          to eq "<p>A test tweet with <a href=\"https://link.com\">a markdown link</a></p>"
       end
     end
   end

--- a/publify_core/spec/models/text_filter_spec.rb
+++ b/publify_core/spec/models/text_filter_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe TextFilter do
 
   describe "#help" do
     it "works for the 'none' filter" do
-      expect(described_class.none.help).to start_with "\n"
+      if TextFilterPlugin.macro_filters.any?
+        expect(described_class.none.help).to start_with "\n"
+      else
+        expect(described_class.none.help).to eq ""
+      end
     end
 
     it "works for the 'markdown' filter" do


### PR DESCRIPTION
- Test full HTML generation for Note instead of internal method result
- Move application of Twitterfilter to postprocess stage
- Make TextFilter#help test pass whether macro filters are present or not
- Make autolinking in notes not break markdown links

Fixes #254.