### PR TITLE
Make notes twitterfilter robust

### DIFF
--- a/publify_core/lib/publify_textfilter_twitterfilter.rb
+++ b/publify_core/lib/publify_textfilter_twitterfilter.rb
@@ -1,12 +1,39 @@
 # frozen_string_literal: true
 
 require "text_filter_plugin"
+require "html/pipeline"
 
 class PublifyApp
   class Textfilter
     class Twitterfilter < TextFilterPlugin::PostProcess
       plugin_display_name "HTML Filter"
       plugin_description "Strip HTML tags"
+
+      class TwitterMentionFilter < HTML::Pipeline::MentionFilter
+        def initialize(text)
+          super(text, base_url: "https://twitter.com")
+        end
+
+        # Override base mentions finder, treating @mention just like any other @foo.
+        def self.mentioned_logins_in(text, username_pattern = UsernamePattern)
+          text.gsub MentionPatterns[username_pattern] do |match|
+            login = Regexp.last_match(1)
+            yield match, login, false
+          end
+        end
+
+        # Override base link creator, removing the class
+        def link_to_mentioned_user(login)
+          result[:mentioned_usernames] |= [login]
+
+          url = base_url.dup
+          url << "/" unless %r{[/~]\z}.match?(url)
+
+          "<a href='#{url << login}'>" \
+            "@#{login}" \
+            "</a>"
+        end
+      end
 
       def self.filtertext(text)
         # First, autolink
@@ -23,14 +50,7 @@ class PublifyApp
           text = text.gsub(item, "<a href='#{uri}'>#{item}</a>")
         end
 
-        # @mention
-        text.to_s.split.grep(/@\w+/) do |item|
-          item = item.strip_html
-          uri = ERB::Util.html_escape("https://twitter.com/#{item.delete("@")}")
-          text = text.gsub(item, "<a href='#{uri}'>#{item}</a>")
-        end
-
-        text
+        TwitterMentionFilter.new(text).call.to_s
       end
     end
   end

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise-i18n", "~> 1.2"
   s.add_dependency "fog-aws", "~> 3.2"
   s.add_dependency "fog-core", "~> 2.2"
+  s.add_dependency "html-pipeline", "~> 2.14"
   s.add_dependency "jquery-rails", "~> 4.4.0"
   s.add_dependency "jquery-ui-rails", "~> 6.0.1"
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog-aws", "~> 3.2"
   s.add_dependency "fog-core", "~> 2.2"
   s.add_dependency "html-pipeline", "~> 2.14"
+  s.add_dependency "html-pipeline-hashtag", "~> 0.1.2"
   s.add_dependency "jquery-rails", "~> 4.4.0"
   s.add_dependency "jquery-ui-rails", "~> 6.0.1"
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]

--- a/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
+++ b/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe PublifyApp::Textfilter::Twitterfilter do
     it "replaces a hashtag with a proper URL to Twitter search" do
       text = described_class.filtertext("A test tweet with a #hashtag")
       expect(text).
-        to eq "A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
-        "&src=tren&mode=realtime'>#hashtag</a>"
+        to eq "A test tweet with a <a href=\"https://twitter.com/search?q=%23hashtag" \
+        "&amp;src=tren&amp;mode=realtime\">#hashtag</a>"
     end
 
     it "replaces a @mention by a proper URL to the twitter account" do
       text = described_class.filtertext("A test tweet with a @mention")
       expect(text).
-        to eq("A test tweet with a <a href='https://twitter.com/mention'>@mention</a>")
+        to eq("A test tweet with a <a href=\"https://twitter.com/mention\">@mention</a>")
     end
 
     it "replaces a http URL by a proper link" do
@@ -31,9 +31,9 @@ RSpec.describe PublifyApp::Textfilter::Twitterfilter do
     it "works with a hashtag and a mention" do
       text = described_class.filtertext("A test tweet with a #hashtag and a @mention")
       expect(text).
-        to eq("A test tweet with a <a href='https://twitter.com/search?q=%23hashtag" \
-              "&src=tren&mode=realtime'>#hashtag</a> and a" \
-              " <a href='https://twitter.com/mention'>@mention</a>")
+        to eq("A test tweet with a <a href=\"https://twitter.com/search?q=%23hashtag" \
+              "&amp;src=tren&amp;mode=realtime\">#hashtag</a> and a" \
+              " <a href=\"https://twitter.com/mention\">@mention</a>")
     end
   end
 end

--- a/publify_core/spec/models/note_spec.rb
+++ b/publify_core/spec/models/note_spec.rb
@@ -298,6 +298,18 @@ RSpec.describe Note, type: :model do
         expect(note.html).
           to eq '<p>A test tweet with <a href="https://link.com">a @mention inside</a></p>'
       end
+
+      it "does not link hashtags inside markdown links" do
+        note = create(:note, body: "A test tweet with [a #markdown link](https://link.com)")
+        expect(note.html).
+          to eq '<p>A test tweet with <a href="https://link.com">a #markdown link</a></p>'
+      end
+
+      it "does not re-link URL anchors" do
+        note = create(:note, body: "A https://link.com#foo")
+        expect(note.html).
+          to eq "<p>A <a href=\"https://link.com#foo\">https://link.com#foo</a></p>"
+      end
     end
   end
 end

--- a/publify_core/spec/models/note_spec.rb
+++ b/publify_core/spec/models/note_spec.rb
@@ -264,14 +264,14 @@ RSpec.describe Note, type: :model do
       it "replaces a hashtag with a proper URL to Twitter search" do
         note = build(:note, body: "A test tweet with a #hashtag")
         expected =
-          "<p>A test tweet with a <a href='https://twitter.com/search?q=%23hashtag&" \
-          "src=tren&mode=realtime'>#hashtag</a></p>"
+          "<p>A test tweet with a <a href=\"https://twitter.com/search?q=%23hashtag&amp;" \
+          "src=tren&amp;mode=realtime\">#hashtag</a></p>"
         expect(note.html).to eq(expected)
       end
 
       it "replaces a @mention by a proper URL to the twitter account" do
         note = create(:note, body: "A test tweet with a @mention")
-        expected = "<p>A test tweet with a <a href='https://twitter.com/mention'>@mention</a></p>"
+        expected = "<p>A test tweet with a <a href=\"https://twitter.com/mention\">@mention</a></p>"
         expect(note.html).to eq(expected)
       end
 
@@ -291,6 +291,12 @@ RSpec.describe Note, type: :model do
         note = create(:note, body: "A test tweet with [a markdown link](https://link.com)")
         expect(note.html).
           to eq "<p>A test tweet with <a href=\"https://link.com\">a markdown link</a></p>"
+      end
+
+      it "does not link a @mention inside a markdown link" do
+        note = create(:note, body: "A test tweet with [a @mention inside](https://link.com)")
+        expect(note.html).
+          to eq '<p>A test tweet with <a href="https://link.com">a @mention inside</a></p>'
       end
     end
   end


### PR DESCRIPTION
- Add specs for more complex Notes markup cases
- Replace `@mention` handling with a robust solution
- Replace `#hashtag` handling with a robust solution
