### PR TITLE
Force minimum nokogiri version to avoid security issues

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
 
     services:
       postgres:
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
 
     services:
       mysql:
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "non-digest-assets", "~> 1.0"
 gem "rake", "~> 13.0"
 gem "reverse_markdown", "~> 2.0"
 
+# Force minimum nokogiri version to avoid security issues
+gem "nokogiri", ">= 1.12.5"
+
 # Force older sprockets
 gem "sprockets", "~> 3.0"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ be broken there at any time, so tread carefully!
 
 To install Publify you need the following:
 
-- CRuby (MRI) 2.4, 2.5, 2.6 or 2.7
+- CRuby (MRI) 2.5, 2.6 or 2.7
 - Ruby on Rails 5.2.x
 - A database engine, MySQL, PgSQL or SQLite3
 - A compatible JavaScript installation for asset compilation. See
@@ -108,7 +108,7 @@ Next, you need to update `Gemfile`. You should remove the `mysql2` and
 ```ruby
 source 'https://rubygems.org'
 
-ruby '2.4.3' # Or whichever version you're running
+ruby '2.7.4' # Or whichever version you're running
 gem 'pg'
 gem 'rails_12factor'
 


### PR DESCRIPTION
This forces Publify users to upgrade nokogiri to at least version 1.12.5, to avoid security issue CVE-2021-41098.
