### PR TITLE
Move nokogiri dependency to gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ AllCops:
   - 'db/schema.rb'
   - 'vendor/bundle/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,6 @@ gem "non-digest-assets", "~> 1.0"
 gem "rake", "~> 13.0"
 gem "reverse_markdown", "~> 2.0"
 
-# Force minimum nokogiri version to avoid security issues
-gem "nokogiri", ">= 1.12.5"
-
 # Force older sprockets
 gem "sprockets", "~> 3.0"
 

--- a/publify_amazon_sidebar/.rubocop.yml
+++ b/publify_amazon_sidebar/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
   - 'spec/dummy/bin/*'
   - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = "Amazon sidebar for the Publify blogging system."
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.files = File.open("Manifest.txt").readlines.map(&:chomp)
 

--- a/publify_core/.rubocop.yml
+++ b/publify_core/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
   - 'spec/dummy/bin/*'
   - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/publify_core/lib/spam_protection.rb
+++ b/publify_core/lib/spam_protection.rb
@@ -82,16 +82,14 @@ class SpamProtection
   def query_rbls(rbls, *subdomains)
     rbls.each do |rbl|
       subdomains.uniq.each do |d|
-        begin
-          response = IPSocket.getaddress([d, rbl].join("."))
-          if response.start_with?("127.0.0.")
-            throw :hit,
-                  "#{rbl} positively resolved subdomain #{d} => #{response}"
-          end
-        rescue SocketError
-          # NXDOMAIN response => negative:  d is not in RBL
-          next
+        response = IPSocket.getaddress([d, rbl].join("."))
+        if response.start_with?("127.0.0.")
+          throw :hit,
+                "#{rbl} positively resolved subdomain #{d} => #{response}"
         end
+      rescue SocketError
+        # NXDOMAIN response => negative:  d is not in RBL
+        next
       end
     end
     false

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.files       = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "aasm", "~> 5.0"
   s.add_dependency "akismet", "~> 3.0"

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -35,6 +35,8 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-ui-rails", "~> 6.0.1"
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]
   s.add_dependency "mini_magick", ["~> 4.9", ">= 4.9.4"]
+  # Force minimum nokogiri version to avoid security issues
+  s.add_dependency "nokogiri", ">= 1.12.5"
   s.add_dependency "rack", ">= 2.2.3"
   s.add_dependency "rails", "~> 5.2.6"
   s.add_dependency "rails_autolink", "~> 1.1.0"

--- a/publify_core/spec/helpers/base_helper_spec.rb
+++ b/publify_core/spec/helpers/base_helper_spec.rb
@@ -121,29 +121,25 @@ describe BaseHelper, type: :helper do
     end
 
     it "returns a link with the creation date and time" do
-      begin
-        timezone = Time.zone
-        Time.zone = "UTC"
+      timezone = Time.zone
+      Time.zone = "UTC"
 
-        expect(get_reply_context_twitter_link(reply)).
-          to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-          "23/01/2014 at 13h47</a>"
-      ensure
-        Time.zone = timezone
-      end
+      expect(get_reply_context_twitter_link(reply)).
+        to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
+        "23/01/2014 at 13h47</a>"
+    ensure
+      Time.zone = timezone
     end
 
     it "displays creation date and time in the current time zone" do
-      begin
-        timezone = Time.zone
-        Time.zone = "Tokyo"
+      timezone = Time.zone
+      Time.zone = "Tokyo"
 
-        expect(get_reply_context_twitter_link(reply)).
-          to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-          "23/01/2014 at 22h47</a>"
-      ensure
-        Time.zone = timezone
-      end
+      expect(get_reply_context_twitter_link(reply)).
+        to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
+        "23/01/2014 at 22h47</a>"
+    ensure
+      Time.zone = timezone
     end
   end
 

--- a/publify_textfilter_code/.rubocop.yml
+++ b/publify_textfilter_code/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
   - 'spec/dummy/bin/*'
   - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/publify_textfilter_code/lib/publify_app/textfilter_code.rb
+++ b/publify_textfilter_code/lib/publify_app/textfilter_code.rb
@@ -50,7 +50,7 @@ PHP (&#42;), Python (&#42;), RHTML, Ruby, Scheme, SQL (&#42;), XHTML, XML, YAML.
                     DEFAULT_OPTIONS
                   end
 
-        text = text.to_s.delete("\r").gsub(/\A\n/, "").chomp
+        text = text.to_s.delete("\r").delete_prefix("\n").chomp
 
         begin
           text = CodeRay.scan(text, lang.downcase.to_sym).span(options)

--- a/publify_textfilter_code/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code/publify_textfilter_code.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files       = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.5.0"
 
   s.add_dependency "coderay", "~> 1.1.0"
   s.add_dependency "htmlentities", "~> 4.3"


### PR DESCRIPTION
- Move explicit Nokogiri version specification to publify_core gem
- Bump required_ruby_version for engine gems
