### PR TITLE
Disallow registration rather than hiding it

### DIFF
--- a/publify_core/Manifest.txt
+++ b/publify_core/Manifest.txt
@@ -142,6 +142,7 @@ app/controllers/tags_controller.rb
 app/controllers/text_controller.rb
 app/controllers/textfilter_controller.rb
 app/controllers/theme_controller.rb
+app/controllers/users/registrations_controller.rb
 app/controllers/xml_controller.rb
 app/helpers/admin/base_helper.rb
 app/helpers/admin/feedback_helper.rb

--- a/publify_core/app/controllers/users/registrations_controller.rb
+++ b/publify_core/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  include BlogHelper
+  before_action :require_signup_allowed
+
+  private
+
+  def require_signup_allowed
+    render plain: "Not found", status: :not_found unless this_blog.allow_signup?
+  end
+end

--- a/publify_core/config/routes.rb
+++ b/publify_core/config/routes.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
+
   # TODO: use only in archive sidebar. See how made other system
   get ":year/:month", to: "articles#index", year: /\d{4}/, month: /\d{1,2}/,
                       as: "articles_by_month", format: false

--- a/publify_core/spec/features/signup_spec.rb
+++ b/publify_core/spec/features/signup_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 
 RSpec.feature "Signing up", type: :feature do
   before do
-    stub_request(:get,
-                 "http://www.google.com/search?output=rss&q=link:www.example.com&tbm=blg").
-      to_return(status: 200, body: "", headers: {})
     load Rails.root.join("db/seeds.rb")
     Blog.first.update(blog_name: "Awesome!",
                       base_url: "http://www.example.com/",
@@ -40,6 +37,18 @@ RSpec.feature "Signing up", type: :feature do
     expect(page).to have_text I18n.t!("devise.sessions.signed_in")
 
     # Confirm proper setting fo user properties
-    expect(User.last.email).to eq "hello@hello.com"
+    u = User.last
+    expect(u.email).to eq "hello@hello.com"
+    expect(u.profile).to eq "contributor"
+  end
+
+  scenario "Disallow account sign-up link with a blog setting" do
+    Blog.first.update(allow_signup: 0)
+    visit admin_dashboard_path
+    expect(page).not_to have_link I18n.t("accounts.create_account")
+
+    visit new_user_registration_path
+
+    expect(page.status_code).to eq 404
   end
 end


### PR DESCRIPTION
Previously, the allow_signup setting only hid the signup link from the login page. With this change, the registration functionality itself is also disabled.