### PR TITLE
Tell the browser not to cache the admin pages

### DIFF
--- a/publify_core/app/controllers/admin/base_controller.rb
+++ b/publify_core/app/controllers/admin/base_controller.rb
@@ -10,6 +10,7 @@ class Admin::BaseController < BaseController
   layout "administration"
 
   before_action :login_required, except: [:login, :signup]
+  before_action :no_caching
 
   private
 
@@ -23,5 +24,10 @@ class Admin::BaseController < BaseController
     flash[:notice] = I18n.t("admin.base.successfully_deleted",
                             name: controller_name.humanize)
     redirect_to action: "index"
+  end
+
+  def no_caching
+    response.cache_control[:extras] =
+      ["no-cache", "max-age=0", "must-revalidate", "no-store"]
   end
 end

--- a/publify_core/spec/requests/admin/dashboard_spec.rb
+++ b/publify_core/spec/requests/admin/dashboard_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Dashboard", type: :request do
+  before do
+    create(:blog)
+    henri = create(:user, :as_admin)
+    sign_in henri
+  end
+
+  describe "GET /admin" do
+    it "tells the browser not to cache" do
+      get admin_dashboard_path
+      expect(response.headers["Cache-Control"]).
+        to eq "private, no-cache, max-age=0, must-revalidate, no-store"
+    end
+  end
+end


### PR DESCRIPTION
After logging out, it should not be possible to view the admin pages without reloading.