### PR TITLE
Only allow certain file types to be uploaded as resources

### DIFF
--- a/publify_core/Manifest.txt
+++ b/publify_core/Manifest.txt
@@ -417,6 +417,7 @@ lib/publify_core/testing_support/factories.rb
 lib/publify_core/testing_support/feed_assertions.rb
 lib/publify_core/testing_support/fixtures/exploit.svg
 lib/publify_core/testing_support/fixtures/fakepng.png
+lib/publify_core/testing_support/fixtures/just_some.html
 lib/publify_core/testing_support/fixtures/otherfile.txt
 lib/publify_core/testing_support/fixtures/testfile.png
 lib/publify_core/testing_support/fixtures/testfile.txt

--- a/publify_core/app/uploaders/resource_uploader.rb
+++ b/publify_core/app/uploaders/resource_uploader.rb
@@ -6,6 +6,10 @@ class ResourceUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   before :cache, :check_image_content_type!
 
+  def content_type_allowlist
+    [%r{image/}, %r{audio/}, %r{video/}, "text/plain"]
+  end
+
   def store_dir
     "files/#{model.class.to_s.underscore}/#{model.id}"
   end

--- a/publify_core/lib/publify_core/testing_support/fixtures/just_some.html
+++ b/publify_core/lib/publify_core/testing_support/fixtures/just_some.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <p>Hello!</p>
+  </body>
+</html>

--- a/publify_core/spec/controllers/admin/resources_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/resources_controller_spec.rb
@@ -160,6 +160,33 @@ describe Admin::ResourcesController, type: :controller do
       end
     end
 
+    context "when attempting to upload an html file" do
+      let(:upload) { file_upload("just_some.html", "text/html") }
+
+      it "does not create a new Resource" do
+        expect { post :upload, params: { upload: upload } }.
+          not_to change(Resource, :count)
+      end
+
+      it "warns the user they can't upload this type of file" do
+        post :upload, params: { upload: upload }
+        result = assigns(:up)
+        expect(result.errors[:upload]).
+          to match_array [
+            %r{You are not allowed to upload text/html files},
+            "can't be blank",
+          ]
+      end
+
+      it "sets the flash to failure" do
+        post :upload, params: { upload: upload }
+        aggregate_failures do
+          expect(flash[:success]).to be_nil
+          expect(flash[:warning]).not_to be_nil
+        end
+      end
+    end
+
     context "when uploading nothing" do
       it "does not create a new Resource" do
         expect { post :upload }.


### PR DESCRIPTION
This is mainly to disallow uploading html files, but there may be other dangerous file types so using an allowlist is safer.

For now, images, audio, video and plain text are allowed since the resources are meant to be used as a media library.