### PR TITLE
Bump puma version to protect against CVE-2021-41136

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "sqlite3", "~> 1.4.0"
 gem "activerecord-session_store", "~> 2.0.0"
 
 # Use Puma as the app server
-gem "puma", "~> 5.3.2"
+gem "puma", "~> 5.5.2"
 
 gem "publify_amazon_sidebar", path: "publify_amazon_sidebar"
 gem "publify_core", path: "publify_core"


### PR DESCRIPTION
See https://github.com/advisories/GHSA-48w2-rm65-62xx
