### PR TITLE
Add documentation about use of the media library

### DIFF
--- a/publify_core/app/views/admin/resources/index.html.erb
+++ b/publify_core/app/views/admin/resources/index.html.erb
@@ -2,6 +2,9 @@
   <h2>
     <%= t('.media_library') %>
   </h2>
+  <p>
+    <%= t('.explain_media_library_html') %>
+  </p>
 <% end %>
 
 <%= form_tag({ action: 'upload' }, { enctype: 'multipart/form-data', class: 'form-inline' }) do %>

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -334,6 +334,9 @@ da:
         content_type: Indholdstype (Content Type)
         date: Dato
         delete: Slet
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Filstørrelse
         filename: Filnavn
         media_library: Media Library

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -334,6 +334,9 @@ de:
         content_type: Content Type
         date: Date
         delete: Löschen
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Dateigröße
         filename: Dateiname
         media_library: Media Library

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -334,6 +334,9 @@ en:
         content_type: Content Type
         date: Date
         delete: Delete
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: File Size
         filename: Filename
         media_library: Media Library

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -334,6 +334,9 @@ es-MX:
         content_type: Content Type
         date: Date
         delete: Eliminar
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Tama&ntilde;o del Archivo
         filename: Nombre del archivo
         media_library: Media Library

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -338,6 +338,9 @@ fr:
         content_type: Type de contenu
         date: Date
         delete: Supprimer
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Taille du fichier
         filename: Fichier
         media_library: Bibliothèque de médias

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -333,6 +333,9 @@ he:
         content_type: סוג התוכן
         date: תאריך
         delete: מחק
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: גודל הקובץ
         filename: שם הקובץ
         media_library: Media Library

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -334,6 +334,9 @@ it:
         content_type: Tipo di contenuto
         date: Date
         delete: Elimina
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Dimensione
         filename: Nome del file
         media_library: Media Library

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -333,6 +333,9 @@ ja:
         content_type: コンテンツタイプ
         date: 日付
         delete: 削除
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: ファイルサイズ
         filename: ファイル名
         media_library: Media Library

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -346,6 +346,9 @@ lt:
         content_type: Content Type
         date: Date
         delete: Trinti
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Dateigröße
         filename: Dateiname
         media_library: Media Library

--- a/publify_core/config/locales/nb-NO.yml
+++ b/publify_core/config/locales/nb-NO.yml
@@ -333,6 +333,9 @@ nb-NO:
         content_type: Innholdstype (MIME Content Type)
         date: Dato
         delete: Slett
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Filstørrelse
         filename: Filnavn
         media_library: Media-bibliotek

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -334,9 +334,13 @@ nl:
         content_type: Content Type
         date: Datum
         delete: Verwijderen
+        explain_media_library_html: Upload hier plaatjes, video en audio om te gebruiken
+          in blog posts en pagina's. Let op dat <strong>alle geüploade bestanden openbaar
+          toegankelijk zijn, zelfs als ze niet gebruikt worden in een blog post of
+          pagina.</strong>.
         file_size: Bestandsgrootte
         filename: Bestandsnaam
-        media_library: Media Library
+        media_library: Mediabibliotheek
         medium_size: Medium size
         no_resources: Er zijn nog geen media. Waarom begin je er niet een te maken?
         original_size: Original size
@@ -556,7 +560,7 @@ nl:
         logged_in_as: Logged in as %{login}
         logout_html: Log out &raquo;
         manage_users: Manage Users
-        media_library: Media Library
+        media_library: Mediabibliotheek
         new: Nieuw
         new_article: Nieuw artikel
         new_media: New Media

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -358,6 +358,9 @@ pl:
         content_type: Typ treści
         date: Data
         delete: Usuń
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Rozmiar pliku
         filename: Nazwa pliku
         media_library: Biblioteka multimediów

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -335,6 +335,9 @@ pt-BR:
         content_type: Tipo de conteúdo
         date: Data
         delete: Remover
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Tamanho do arquivo
         filename: Nome do arquivo
         media_library: Biblioteca

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -346,6 +346,9 @@ ro:
         content_type: Tip de conținut (content type)
         date: Date
         delete: Delete
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Dimensiunea fișierului
         filename: Nume de fișier
         media_library: Media Library

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -358,6 +358,9 @@ ru:
         content_type: Content Type
         date: Дата
         delete: Удалить
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: Размер Файла
         filename: Имя Файла
         media_library: Медиатека
@@ -579,7 +582,7 @@ ru:
         logged_in_as: Вы вошли как %{login}
         logout_html: Выйти »
         manage_users: Управление пользователями
-        media_library: Файлы
+        media_library: Медиатека
         new: Добавить...
         new_article: Новый пост
         new_media: Новый файл

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -330,6 +330,9 @@ zh-CN:
         content_type: 內容類型
         date: 日期
         delete: 删除
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: 檔案大小
         filename: 檔案名稱
         media_library: Media Library

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -331,6 +331,9 @@ zh-TW:
         content_type: 內容類型
         date: Date
         delete: 刪除
+        explain_media_library_html: Upload images, video and audio here for use in
+          your blog posts and pages. Please note that <strong>all uploaded files will
+          be publicly accessible even if they're not used in blog posts or pages</strong>.
         file_size: 檔案大小
         filename: 檔案名稱
         media_library: Media Library


### PR DESCRIPTION
The media library is for images, video and audio, and all files are publicly accessible. Make this purpose and caveat clearer to the user.
