### PR TITLE
Update RuboCop dependencies and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,7 +109,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/*'
 
-Capybara/FeatureMethods:
+RSpec/Capybara/FeatureMethods:
   Exclude:
     - 'spec/features/**_spec.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem "pry", "~> 0.14.0"
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 5.0"
-  gem "rubocop", "~> 1.14.0", require: false
+  gem "rubocop", "~> 1.22.3", require: false
   gem "rubocop-performance", "~> 1.11.3", require: false
   gem "rubocop-rails", "~> 2.10.1", require: false
   gem "rubocop-rspec", "~> 2.3.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -83,5 +83,5 @@ end
 
 # Install gems from each theme
 Dir.glob(File.join(File.dirname(__FILE__), "themes", "**", "Gemfile")) do |gemfile|
-  eval(IO.read(gemfile), binding)
+  eval(File.read(gemfile), binding)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 5.0"
   gem "rubocop", "~> 1.22.3", require: false
-  gem "rubocop-performance", "~> 1.11.3", require: false
+  gem "rubocop-performance", "~> 1.12.0", require: false
   gem "rubocop-rails", "~> 2.10.1", require: false
   gem "rubocop-rspec", "~> 2.3.0", require: false
   gem "simplecov", "~> 0.21.2", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :development, :test do
   gem "rspec-rails", "~> 5.0"
   gem "rubocop", "~> 1.22.3", require: false
   gem "rubocop-performance", "~> 1.12.0", require: false
-  gem "rubocop-rails", "~> 2.10.1", require: false
+  gem "rubocop-rails", "~> 2.12.4", require: false
   gem "rubocop-rspec", "~> 2.3.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development, :test do
   gem "rubocop", "~> 1.22.3", require: false
   gem "rubocop-performance", "~> 1.12.0", require: false
   gem "rubocop-rails", "~> 2.12.4", require: false
-  gem "rubocop-rspec", "~> 2.3.0", require: false
+  gem "rubocop-rspec", "~> 2.6.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end
 

--- a/app/models/authors_sidebar.rb
+++ b/app/models/authors_sidebar.rb
@@ -3,7 +3,7 @@
 class AuthorsSidebar < Sidebar
   display_name "Authors"
   description "Displays a list of authors ordered by name with links to their" \
-    " articles and profile"
+              " articles and profile"
 
   setting :count, true, label: "Show articles number", input_type: :checkbox
 

--- a/lib/publify_avatar_gravatar.rb
+++ b/lib/publify_avatar_gravatar.rb
@@ -32,7 +32,7 @@ module PublifyPlugins
 
         url = +"https://www.gravatar.com/avatar.php?"
         url << opts.map { |key, value| "#{key}=#{value}" }.sort.join("&")
-        tag "img", src: url, class: klass, alt: "Gravatar"
+        tag.img(src: url, class: klass, alt: "Gravatar")
       end
     end
   end

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -7,7 +7,7 @@ class ArticlesController < ContentController
 
   layout :theme_layout, except: [:trackback]
 
-  helper :'admin/base'
+  helper :"admin/base"
 
   def index
     wanted_types = this_blog.statuses_in_timeline ? ["Article", "Note"] : ["Article"]

--- a/publify_core/app/helpers/base_helper.rb
+++ b/publify_core/app/helpers/base_helper.rb
@@ -66,7 +66,7 @@ module BaseHelper
   end
 
   def meta_tag(name, value)
-    tag :meta, name: name, content: value if value.present?
+    tag.meta(name: name, content: value) if value.present?
   end
 
   def markup_help_popup(markup, text)

--- a/publify_core/app/models/meta_sidebar.rb
+++ b/publify_core/app/models/meta_sidebar.rb
@@ -2,7 +2,7 @@
 
 class MetaSidebar < Sidebar
   description "This widget just displays links to Publify main site," \
-    " this blog's admin and RSS."
+              " this blog's admin and RSS."
 
   setting :title, "Meta"
 end

--- a/publify_core/app/models/static_sidebar.rb
+++ b/publify_core/app/models/static_sidebar.rb
@@ -13,7 +13,7 @@ class StaticSidebar < Sidebar
   TEXT
 
   description "Static content, like links to other sites, advertisements," \
-    " or blog meta-information"
+              " or blog meta-information"
 
   setting :title, "Links"
   setting :body, DEFAULT_TEXT, input_type: :text_area

--- a/publify_core/lib/publify_core/testing_support/factories/sequences.rb
+++ b/publify_core/lib/publify_core/testing_support/factories/sequences.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   sequence(:name) { |n| "name_#{n}" }
-  sequence(:body) { |n| "body #{n}" * (n + 3 % 5) }
+  sequence(:body) { |n| "body #{n}" * ((n % 5) + 3) }
   sequence(:user) { |n| "user#{n}" }
   sequence(:email) { |n| "user#{n}@example.com" }
   sequence(:guid) { |n| "deadbeef#{n}" }

--- a/publify_core/lib/publify_textfilter_markdown.rb
+++ b/publify_core/lib/publify_textfilter_markdown.rb
@@ -9,7 +9,7 @@ class PublifyApp
     class Markdown < TextFilterPlugin::Markup
       plugin_display_name "Markdown"
       plugin_description "Markdown markup language from" \
-        ' <a href="http://daringfireball.com/">Daring Fireball</a>'
+                         ' <a href="http://daringfireball.com/">Daring Fireball</a>'
 
       def self.help_text
         <<~TXT

--- a/publify_core/lib/publify_textfilter_markdown_smartquotes.rb
+++ b/publify_core/lib/publify_textfilter_markdown_smartquotes.rb
@@ -7,8 +7,8 @@ module PublifyTextfilter
   class MarkdownSmartquotes < PublifyApp::Textfilter::Markdown
     plugin_display_name "Markdown with smart quotes"
     plugin_description "Markdown markup language from" \
-      ' <a href="http://daringfireball.com/">Daring Fireball</a>' \
-      " with automatic use of typographically correct quotes and dashes"
+                       ' <a href="http://daringfireball.com/">Daring Fireball</a>' \
+                       " with automatic use of typographically correct quotes and dashes"
 
     def self.filtertext(text)
       # FIXME: Workaround for <publify:foo> not being interpreted as an HTML tag.

--- a/publify_core/spec/controllers/admin/feedback_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/feedback_controller_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
         expect(comment.body).to eq("updated comment")
       end
 
-      it "does not  update comment if get request" do
+      it "does not update comment if get request" do
         comment = create(:comment)
         get "update", params: { id: comment.id,
                                 comment: { author: "Bob Foo2",

--- a/publify_core/spec/controllers/admin/settings_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/settings_controller_spec.rb
@@ -48,15 +48,11 @@ RSpec.describe Admin::SettingsController, type: :controller do
     end
 
     context "when updating the language" do
-      after do
-        I18n.locale = :en
-      end
-
       it "sets the flash in the new language" do
-        expect(I18n.locale).to eq :en
-        post :update, params: { setting: { lang: "nl" } }
-        expect(I18n.locale).to eq :nl
-        expect(flash[:success]).to eq I18n.t("admin.settings.update.success")
+        I18n.with_locale :en do
+          post :update, params: { setting: { lang: "nl" } }
+          expect(flash[:success]).to eq I18n.t("admin.settings.update.success", locale: :nl)
+        end
       end
     end
   end

--- a/publify_core/spec/helpers/base_helper_spec.rb
+++ b/publify_core/spec/helpers/base_helper_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe BaseHelper, type: :helper do
       Time.use_zone "UTC" do
         expect(get_reply_context_twitter_link(reply)).
           to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-          "23/01/2014 at 13h47</a>"
+                "23/01/2014 at 13h47</a>"
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe BaseHelper, type: :helper do
       Time.use_zone "Tokyo" do
         expect(get_reply_context_twitter_link(reply)).
           to eq '<a href="https://twitter.com/a_screen_name/status/123456789">' \
-          "23/01/2014 at 22h47</a>"
+                "23/01/2014 at 22h47</a>"
       end
     end
   end

--- a/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
+++ b/publify_core/spec/lib/publify_textfilter_twitterfilter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PublifyApp::Textfilter::Twitterfilter do
       text = described_class.filtertext("A test tweet with a #hashtag")
       expect(text).
         to eq "A test tweet with a <a href=\"https://twitter.com/search?q=%23hashtag" \
-        "&amp;src=tren&amp;mode=realtime\">#hashtag</a>"
+              "&amp;src=tren&amp;mode=realtime\">#hashtag</a>"
     end
 
     it "replaces a @mention by a proper URL to the twitter account" do

--- a/publify_core/spec/lib/publify_time_spec.rb
+++ b/publify_core/spec/lib/publify_time_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe PublifyTime do
   end
 end
 
-RSpec.describe "find Article date range " do
+RSpec.describe "find Article date range" do
   let!(:blog) { create(:blog) }
 
   describe "UTC" do
@@ -120,7 +120,7 @@ RSpec.describe "find Article date range " do
     end
   end
 
-  describe "JST(+0900) " do
+  describe "JST(+0900)" do
     around do |example|
       Time.use_zone("Tokyo", &example)
     end

--- a/publify_core/spec/lib/transforms_spec.rb
+++ b/publify_core/spec/lib/transforms_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe String do
   end
 
   describe "to_url" do
-    it "' this is  a sentence ' should give a proper space-less, trimmed URL" do
+    it "gives a proper space-less, trimmed URL" do
       expect(" this is  a sentence ".to_url).to eq("this-is-a-sentence")
     end
   end

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -580,7 +580,7 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe "an article published just after midnight  JST (+0900)" do
+  describe "an article published just after midnight JST (+0900)" do
     around do |example|
       Time.use_zone("Tokyo", &example)
     end

--- a/publify_core/spec/models/configuration_spec.rb
+++ b/publify_core/spec/models/configuration_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe "Given a new blog", type: :model do
     expect(blog.statuses_title_template).to eq("Notes | %blog_name% %page%")
   end
 
-  it "status list description  is Notes | blog name | blog subtitle page" do
+  it "status list description is Notes | blog name | blog subtitle page" do
     expect(blog.statuses_desc_template).
       to eq("Notes | %blog_name% | %blog_subtitle% %page%")
   end
@@ -223,7 +223,7 @@ RSpec.describe "Given a new blog", type: :model do
     expect(blog.status_title_template).to eq("%body% | %blog_name%")
   end
 
-  it "status list description  is status content" do
+  it "status list description is status content" do
     expect(blog.status_desc_template).to eq("%excerpt%")
   end
 

--- a/publify_core/spec/models/configuration_spec.rb
+++ b/publify_core/spec/models/configuration_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Given a new blog", type: :model do
   end
 
   it "Robots.txt should be empty" do
-    expect(blog.robots).to eq('User-agent: *\\nAllow: /\\nDisallow: /admin\\n')
+    expect(blog.robots).to eq("User-agent: *\\nAllow: /\\nDisallow: /admin\\n")
   end
 
   it "Tags should be indexed" do

--- a/publify_core/spec/models/note_spec.rb
+++ b/publify_core/spec/models/note_spec.rb
@@ -184,11 +184,11 @@ RSpec.describe Note, type: :model do
       context "with a short message much more than 114 char" do
         let(:tweet) do
           "A very big(10) message with lot of text (40)inside just to try the" \
-          " shortener and (80)the new link that publify must create and add at the end"
+            " shortener and (80)the new link that publify must create and add at the end"
         end
         let(:expected_tweet) do
           "A very big(10) message with lot of text (40)inside just to try the" \
-          " shortener and (80)the new link that publify... (#{note.redirect.from_url})"
+            " shortener and (80)the new link that publify... (#{note.redirect.from_url})"
         end
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
@@ -205,7 +205,7 @@ RSpec.describe Note, type: :model do
         end
         let(:expected_tweet) do
           "Le dojo de nantes, c'est comme au McDo, sans les odeurs, et en plus rigolo:" \
-          " RT @abailly Ce midi c'est coding... (#{note.redirect.from_url})"
+            " RT @abailly Ce midi c'est coding... (#{note.redirect.from_url})"
         end
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
@@ -215,12 +215,12 @@ RSpec.describe Note, type: :model do
       context "with a bug message" do
         let(:tweet) do
           '"JSFuck is an esoteric and educational programming style based on the' \
-          " atomic parts of JavaScript. It uses only six different characters to" \
-          ' write and execute code." http://www.jsfuck.com/ '
+            " atomic parts of JavaScript. It uses only six different characters to" \
+            ' write and execute code." http://www.jsfuck.com/ '
         end
         let(:expected_tweet) do
           "\"JSFuck is an esoteric and educational programming style based on the" \
-          " atomic parts of JavaScript. It uses only... (#{note.redirect.from_url})"
+            " atomic parts of JavaScript. It uses only... (#{note.redirect.from_url})"
         end
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
@@ -230,11 +230,11 @@ RSpec.describe Note, type: :model do
       context "don't cut word" do
         let(:tweet) do
           "Le #mobprogramming c'est un peu comme faire un dojo sur une journée entière" \
-          " (ça permet sûrement de faire des petites journées ;-))"
+            " (ça permet sûrement de faire des petites journées ;-))"
         end
         let(:expected_tweet) do
           "Le #mobprogramming c'est un peu comme faire un dojo sur une journée entière" \
-          " (ça permet sûrement de faire des... (#{note.redirect.from_url})"
+            " (ça permet sûrement de faire des... (#{note.redirect.from_url})"
         end
 
         it { expect(note.twitter_message).to eq(expected_tweet) }
@@ -244,11 +244,11 @@ RSpec.describe Note, type: :model do
       context "shortener host name is counted as an url by twitter" do
         let(:tweet) do
           "RT @stephaneducasse http://pharocloud.com is so cool. I love love such idea" \
-          " and I wish them success. Excellent work."
+            " and I wish them success. Excellent work."
         end
         let(:expected_tweet) do
           "RT @stephaneducasse http://pharocloud.com is so cool. I love love such idea" \
-          " and I wish them success. Excellent... (#{note.redirect.from_url})"
+            " and I wish them success. Excellent... (#{note.redirect.from_url})"
         end
 
         it { expect(note.twitter_message).to eq(expected_tweet) }

--- a/publify_core/spec/views/articles/index_atom_feed_spec.rb
+++ b/publify_core/spec/views/articles/index_atom_feed_spec.rb
@@ -156,7 +156,8 @@ RSpec.describe "articles/index_atom_feed.atom.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.content).
           to eq "<p>This article is password protected. Please" \
-                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a>" \
+                " to read it</p>"
       end
 
       it "does not have a summary element in addition to the content element" do

--- a/publify_core/spec/views/articles/index_atom_feed_spec.rb
+++ b/publify_core/spec/views/articles/index_atom_feed_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe "articles/index_atom_feed.atom.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.content).
           to eq "<p>This article is password protected. Please" \
-                 " <a href='#{@article.permalink_url}'>fill in your password</a>" \
-                 " to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a>" \
+                " to read it</p>"
       end
 
       it "does not have a summary element in addition to the content element" do
@@ -156,7 +156,7 @@ RSpec.describe "articles/index_atom_feed.atom.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.content).
           to eq "<p>This article is password protected. Please" \
-          " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
       end
 
       it "does not have a summary element in addition to the content element" do

--- a/publify_core/spec/views/articles/index_rss_feed_spec.rb
+++ b/publify_core/spec/views/articles/index_rss_feed_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "articles/index_rss_feed.rss.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.summary).
           to eq "<p>This article is password protected. Please" \
-          " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
       end
 
       it "does not show any secret bits anywhere" do
@@ -144,7 +144,7 @@ RSpec.describe "articles/index_rss_feed.rss.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.summary).
           to eq "<p>This article is password protected. Please" \
-          " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
       end
 
       it "does not show any secret bits anywhere" do

--- a/publify_core/spec/views/articles/index_rss_feed_spec.rb
+++ b/publify_core/spec/views/articles/index_rss_feed_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe "articles/index_rss_feed.rss.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.summary).
           to eq "<p>This article is password protected. Please" \
-                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a>" \
+                " to read it</p>"
       end
 
       it "does not show any secret bits anywhere" do
@@ -144,7 +145,8 @@ RSpec.describe "articles/index_rss_feed.rss.builder", type: :view do
       it "shows only a link to the article" do
         expect(rendered_entry.summary).
           to eq "<p>This article is password protected. Please" \
-                " <a href='#{@article.permalink_url}'>fill in your password</a> to read it</p>"
+                " <a href='#{@article.permalink_url}'>fill in your password</a>" \
+                " to read it</p>"
       end
 
       it "does not show any secret bits anywhere" do

--- a/publify_core/spec/views/feedback/index.atom.builder_spec.rb
+++ b/publify_core/spec/views/feedback/index.atom.builder_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "feedback/index.atom.builder", type: :view do
       it "has all the required attributes" do
         expect(rendered_entry.title).
           to eq "Trackback from #{trackback.blog_name}:" \
-          " #{trackback.title} on #{article.title}"
+                " #{trackback.title} on #{article.title}"
         expect(rendered_entry.entry_id).to eq("urn:uuid:dsafsadffsdsf")
         expect(rendered_entry.summary).to eq("This is an excerpt")
         expect(rendered_entry.links.first).

--- a/publify_core/spec/views/feedback/index.rss.builder_spec.rb
+++ b/publify_core/spec/views/feedback/index.rss.builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "feedback/index.rss.builder", type: :view do
       it "has all the required attributes" do
         expect(rendered_entry.title).
           to eq "Trackback from #{trackback.blog_name}:" \
-          " #{trackback.title} on #{article.title}"
+                " #{trackback.title} on #{article.title}"
         expect(rendered_entry.entry_id).to eq("urn:uuid:dsafsadffsdsf")
         expect(rendered_entry.summary).to eq("This is an excerpt")
         expect(xml_entry.css("link").first.content).to eq(trackback.url)


### PR DESCRIPTION
- Update rubocop to version 1.22.3
- Update rubocop-performance to version 1.12.0
- Update rubocop-rails to version 2.12.4
- Update rubocop-rspec to version 2.6.0
- Autocorrect Layout/LineEndStringConcatenationIndentation
- Autocorrect Security/IoMethods
- Update cop namespace for Capybara/FeatureMethods
- Correct RSpec/ExcessiveDocstringSpacing
- Autocorrect Rails/ContentTag
- Autocorrect Style/QuotedSymbols
- Autocorrect Style/StringLiterals
- Fix sequence expression
- Correct Rails/I18nLocaleAssignment offense
- Wrap long lines
