### PR TITLE
Fix setting the article password from the Admin

### DIFF
--- a/publify_core/app/controllers/admin/content_controller.rb
+++ b/publify_core/app/controllers/admin/content_controller.rb
@@ -180,6 +180,7 @@ class Admin::ContentController < Admin::BaseController
              :body_and_extended,
              :draft,
              :extended,
+             :password,
              :permalink,
              :published_at,
              :text_filter_name,

--- a/publify_core/spec/controllers/admin/content_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/content_controller_spec.rb
@@ -160,6 +160,12 @@ describe Admin::ContentController, type: :controller do
         assert_equal 2, new_article.tags.size
       end
 
+      it "creates an article with a password" do
+        post :create, params: { "article" => base_article(password: "foobar") }
+        new_article = Article.last
+        expect(new_article.password).to eq("foobar")
+      end
+
       it "creates an article with a unique Tag instance named lang:FR" do
         post :create, params: { "article" => base_article(keywords: "lang:FR") }
         new_article = Article.last
@@ -390,6 +396,15 @@ describe Admin::ContentController, type: :controller do
         article.reload
         expect(article.body).to eq("foo")
         expect(article.extended).to eq("bar<!--more-->baz")
+      end
+
+      it "allows updating password" do
+        put :update, params: { "id" => article.id, "article" => {
+          "password" => "foobar",
+        } }
+        assert_response :redirect
+        article.reload
+        expect(article.password).to eq("foobar")
       end
 
       context "when a published article has drafts" do


### PR DESCRIPTION
The password field was present in the form, but not accepted by the controller. This change adds password to the list of accepted fields.
