### PR TITLE
Disallow comments on draft articles

### DIFF
--- a/publify_core/app/controllers/admin/content_controller.rb
+++ b/publify_core/app/controllers/admin/content_controller.rb
@@ -131,7 +131,7 @@ class Admin::ContentController < Admin::BaseController
     end
   end
 
-  protected
+  private
 
   def fetch_fresh_or_existing_draft_for_article
     return unless @article.published? && @article.id
@@ -145,8 +145,6 @@ class Admin::ContentController < Admin::BaseController
   end
 
   attr_accessor :resources, :resource
-
-  private
 
   def load_resources
     @post_types = PostType.all

--- a/publify_core/app/controllers/comments_controller.rb
+++ b/publify_core/app/controllers/comments_controller.rb
@@ -28,7 +28,7 @@ class CommentsController < BaseController
     @comment = @article.comments.build(comment_params)
   end
 
-  protected
+  private
 
   def recaptcha_ok_for?(comment)
     use_recaptcha = comment.blog.use_recaptcha

--- a/publify_core/app/controllers/comments_controller.rb
+++ b/publify_core/app/controllers/comments_controller.rb
@@ -7,11 +7,6 @@ class CommentsController < BaseController
     options = new_comment_defaults.merge comment_params.to_h
     @comment = @article.add_comment(options)
 
-    unless current_user.nil? || session[:user_id].nil?
-      # maybe useless, but who knows ?
-      @comment.user_id = current_user.id if current_user.id == session[:user_id]
-    end
-
     remember_author_info_for @comment
 
     partial = "/articles/comment_failed"
@@ -43,7 +38,7 @@ class CommentsController < BaseController
   def new_comment_defaults
     { ip: request.remote_ip,
       author: "Anonymous",
-      user: @current_user,
+      user: current_user,
       user_agent: request.env["HTTP_USER_AGENT"],
       referrer: request.env["HTTP_REFERER"],
       permalink: @article.permalink_url }.stringify_keys

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -216,7 +216,7 @@ class Article < Content
   end
 
   def pings_closed?
-    !(allow_pings? && in_feedback_window?)
+    !(allow_pings? && published? && in_feedback_window?)
   end
 
   # check if time to comment is open or not

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -204,7 +204,7 @@ class Article < Content
   end
 
   def comments_closed?
-    !(allow_comments? && in_feedback_window?)
+    !(allow_comments? && published? && in_feedback_window?)
   end
 
   def html_urls

--- a/publify_core/app/models/comment.rb
+++ b/publify_core/app/models/comment.rb
@@ -38,7 +38,7 @@ class Comment < Feedback
     really_send_notifications
   end
 
-  protected
+  private
 
   def article_allows_feedback?
     return true if article.allow_comments?

--- a/publify_core/lib/spam_protection.rb
+++ b/publify_core/lib/spam_protection.rb
@@ -31,7 +31,7 @@ class SpamProtection
     end
   end
 
-  protected
+  private
 
   def scan_ip(ip_address)
     logger.info("[SP] Scanning IP #{ip_address}")

--- a/publify_core/spec/controllers/admin/content_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/content_controller_spec.rb
@@ -43,27 +43,23 @@ describe Admin::ContentController, type: :controller do
         create(:article, state: "publication_pending", published_at: "2020-01-01")
       end
 
-      before { get :index, params: { search: state } }
+      it "returns draft articles when drafts is specified" do
+        get :index, params: { search: { state: "drafts" } }
 
-      context "draft only" do
-        let(:state) { { state: "drafts" } }
-
-        it { expect(assigns(:articles)).to eq([draft_article]) }
+        expect(assigns(:articles)).to eq([draft_article])
       end
 
-      context "publication_pending only" do
-        let(:state) { { state: "pending" } }
+      it "returns pending articles when pending is specified" do
+        get :index, params: { search: { state: "pending" } }
 
-        it { expect(assigns(:articles)).to eq([pending_article]) }
+        expect(assigns(:articles)).to eq([pending_article])
       end
 
-      context "with a bad state" do
-        let(:state) { { state: "3vI1 1337 h4x0r" } }
+      it "returns all states when called with a bad state" do
+        get :index, params: { search: { state: "3vI1 1337 h4x0r" } }
 
-        it "returns all states" do
-          expect(assigns(:articles).sort).
-            to eq([article, pending_article, draft_article].sort)
-        end
+        expect(assigns(:articles).sort).
+          to eq([article, pending_article, draft_article].sort)
       end
     end
   end

--- a/publify_core/spec/controllers/comments_controller_spec.rb
+++ b/publify_core/spec/controllers/comments_controller_spec.rb
@@ -11,52 +11,51 @@ RSpec.describe CommentsController, type: :controller do
   end
 
   describe "#create" do
-    context "when using regular post" do
-      it "creates a comment on the specified article" do
-        post :create, params: { comment: comment_params, article_id: article.id }
-        aggregate_failures do
-          expect(article.comments.size).to eq(1)
-          comment = article.comments.last
-          expect(comment.author).to eq("bob")
-          expect(comment.body).to eq("content")
-          expect(comment.email).to eq("bob@home")
-          expect(comment.url).to eq("http://bobs.home/")
-        end
-      end
+    render_views
 
-      it "remembers author info in cookies" do
-        post :create, params: { comment: comment_params, article_id: article.id }
-        aggregate_failures do
-          expect(cookies["author"]).to eq("bob")
-          expect(cookies["gravatar_id"]).to eq(Digest::MD5.hexdigest("bob@home"))
-          expect(cookies["url"]).to eq("http://bobs.home/")
-        end
-      end
-
-      it "redirects to the article" do
-        post :create, params: { comment: comment_params, article_id: article.id }
-        expect(response).to redirect_to article.permalink_url
-      end
-
-      it "sets the user if logged in" do
-        sign_in user
-        post :create, params: { comment: comment_params, article_id: article.id }
+    it "creates a comment on the specified article" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
+        expect(article.comments.size).to eq(1)
         comment = article.comments.last
-        expect(comment.user).to eq user
+        expect(comment.author).to eq("bob")
+        expect(comment.body).to eq("content")
+        expect(comment.email).to eq("bob@home")
+        expect(comment.url).to eq("http://bobs.home/")
       end
     end
 
-    context "when using xhr post" do
-      before do
-        post :create, xhr: true, params: { comment: comment_params, article_id: article.id }
+    it "remembers author info in cookies" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
+        expect(cookies["author"]).to eq("bob")
+        expect(cookies["gravatar_id"]).to eq(Digest::MD5.hexdigest("bob@home"))
+        expect(cookies["url"]).to eq("http://bobs.home/")
       end
+    end
 
-      it "assigns the created comment for rendering" do
-        expect(assigns[:comment]).to eq article.comments.last
-      end
+    it "sets the user if logged in" do
+      sign_in user
+      post :create, params: { comment: comment_params, article_id: article.id }
+      comment = article.comments.last
+      expect(comment.user).to eq user
+    end
 
-      it "renders the comment partial" do
+    it "assigns the created comment" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      expect(assigns[:comment]).to eq article.comments.last
+    end
+
+    it "redirects to the article when using regular post" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      expect(response).to redirect_to article.permalink_url
+    end
+
+    it "renders the comment when using xhr post" do
+      post :create, xhr: true, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
         expect(response).to render_template("articles/comment")
+        expect(response.body).to have_text "content"
       end
     end
   end

--- a/publify_core/spec/controllers/comments_controller_spec.rb
+++ b/publify_core/spec/controllers/comments_controller_spec.rb
@@ -2,20 +2,18 @@
 
 require "rails_helper"
 
-describe CommentsController, type: :controller do
+RSpec.describe CommentsController, type: :controller do
   let!(:blog) { create(:blog) }
   let(:article) { create(:article) }
+  let(:user) { create(:user) }
   let(:comment_params) do
     { body: "content", author: "bob", email: "bob@home", url: "http://bobs.home/" }
   end
 
   describe "#create" do
     context "when using regular post" do
-      before do
-        post :create, params: { comment: comment_params, article_id: article.id }
-      end
-
       it "creates a comment on the specified article" do
+        post :create, params: { comment: comment_params, article_id: article.id }
         aggregate_failures do
           expect(article.comments.size).to eq(1)
           comment = article.comments.last
@@ -27,6 +25,7 @@ describe CommentsController, type: :controller do
       end
 
       it "remembers author info in cookies" do
+        post :create, params: { comment: comment_params, article_id: article.id }
         aggregate_failures do
           expect(cookies["author"]).to eq("bob")
           expect(cookies["gravatar_id"]).to eq(Digest::MD5.hexdigest("bob@home"))
@@ -35,7 +34,15 @@ describe CommentsController, type: :controller do
       end
 
       it "redirects to the article" do
+        post :create, params: { comment: comment_params, article_id: article.id }
         expect(response).to redirect_to article.permalink_url
+      end
+
+      it "sets the user if logged in" do
+        sign_in user
+        post :create, params: { comment: comment_params, article_id: article.id }
+        comment = article.comments.last
+        expect(comment.user).to eq user
       end
     end
 

--- a/publify_core/spec/controllers/comments_controller_spec.rb
+++ b/publify_core/spec/controllers/comments_controller_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe CommentsController, type: :controller do
         expect(response.body).to have_text "content"
       end
     end
+
+    it "does not allow commenting if article does not allow comments" do
+      no_comments = create(:article, allow_comments: false)
+      expect do
+        post :create, xhr: true, params: { comment: comment_params,
+                                           article_id: no_comments.id }
+      end.not_to change(no_comments.comments, :count)
+    end
+
+    it "does not allow commenting if article is draft" do
+      draft = create(:article, state: "draft")
+      expect do
+        post :create, xhr: true, params: { comment: comment_params, article_id: draft.id }
+      end.not_to change(draft.comments, :count)
+    end
   end
 
   describe "#preview" do

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -422,18 +422,25 @@ describe Article, type: :model do
     end
   end
 
-  it "test_can_ping_fresh_article_iff_it_allows_pings" do
-    a = create(:article, allow_pings: true)
-    assert_equal(false, a.pings_closed?)
-    a.allow_pings = false
-    assert_equal(true, a.pings_closed?)
-  end
+  describe "#pings_closed?" do
+    let!(:blog) do
+      create(:blog, sp_article_auto_close: 30)
+    end
 
-  it "test_cannot_ping_old_article" do
-    a = create(:article, allow_pings: false)
-    assert_equal(true, a.pings_closed?)
-    a.allow_pings = false
-    assert_equal(true, a.pings_closed?)
+    it "returns false for a fresh article if it allows pings" do
+      a = create(:article, allow_pings: true)
+      assert_equal(false, a.pings_closed?)
+    end
+
+    it "returns true for a fresh article if it does not allow pings" do
+      a = create(:article, allow_pings: false)
+      assert_equal(true, a.pings_closed?)
+    end
+
+    it "returns true for an old article even if it allows pings" do
+      a = create(:article, published_at: 31.days.ago, allow_pings: true)
+      assert_equal(true, a.pings_closed?)
+    end
   end
 
   describe "#published_at_like" do

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -441,6 +441,17 @@ describe Article, type: :model do
       a = create(:article, published_at: 31.days.ago, allow_pings: true)
       assert_equal(true, a.pings_closed?)
     end
+
+    it "returns true for a draft article even if it allows pings" do
+      a = create(:article, state: "draft", allow_pings: true)
+      assert_equal(true, a.pings_closed?)
+    end
+
+    it "returns true for a pending article even if it allows pings" do
+      a = create(:article, state: "publication_pending", published_at: 1.day.from_now,
+                           allow_pings: true)
+      assert_equal(true, a.pings_closed?)
+    end
   end
 
   describe "#published_at_like" do

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -856,8 +856,9 @@ describe Article, type: :model do
     it "returns only published articles" do
       article = create(:article)
       create(:comment, article: article)
-      unpublished_article = create(:article, state: "draft")
+      unpublished_article = create(:article)
       create(:comment, article: unpublished_article)
+      unpublished_article.update!(state: "draft")
       expect(described_class.published).to eq([article])
       expect(described_class.bestof).to eq([article])
     end
@@ -954,6 +955,17 @@ describe Article, type: :model do
 
     context "when auto_close setting is zero" do
       let(:auto_close_value) { 0 }
+
+      it "does not allow comments for a draft article" do
+        art = build :article, state: "draft", blog: blog
+        assert art.comments_closed?
+      end
+
+      it "does not allow comments for an article that will be published in the future" do
+        art = build :article, state: "publication_pending",
+                              published_at: 1.day.from_now, blog: blog
+        assert art.comments_closed?
+      end
 
       it "allows comments for a newly published article" do
         art = build :article, published_at: 1.second.ago, blog: blog

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -507,16 +507,13 @@ describe Article, type: :model do
   end
 
   describe "an article published just before midnight UTC" do
-    before do
-      @timezone = Time.zone
-      Time.zone = "UTC"
-      @a = build(:article)
-      @a.set_permalink
-      @a.published_at = "21 Feb 2011 23:30 UTC"
-    end
-
-    after do
-      Time.zone = @timezone
+    around do |example|
+      Time.use_zone "UTC" do
+        @a = build(:article)
+        @a.set_permalink
+        @a.published_at = "21 Feb 2011 23:30 UTC"
+        example.call
+      end
     end
 
     describe "#permalink_url" do
@@ -536,16 +533,13 @@ describe Article, type: :model do
   end
 
   describe "an article published just after midnight UTC" do
-    before do
-      @timezone = Time.zone
-      Time.zone = "UTC"
-      @a = build(:article)
-      @a.set_permalink
-      @a.published_at = "22 Feb 2011 00:30 UTC"
-    end
-
-    after do
-      Time.zone = @timezone
+    around do |example|
+      Time.use_zone "UTC" do
+        @a = build(:article)
+        @a.set_permalink
+        @a.published_at = "22 Feb 2011 00:30 UTC"
+        example.call
+      end
     end
 
     describe "#permalink_url" do
@@ -565,16 +559,13 @@ describe Article, type: :model do
   end
 
   describe "an article published just before midnight JST (+0900)" do
-    before do
-      @time_zone = Time.zone
-      Time.zone = "Tokyo"
-      @a = build(:article)
-      @a.set_permalink
-      @a.published_at = "31 Dec 2012 23:30 +0900"
-    end
-
-    after do
-      Time.zone = @time_zone
+    around do |example|
+      Time.use_zone "Tokyo" do
+        @a = build(:article)
+        @a.set_permalink
+        @a.published_at = "31 Dec 2012 23:30 +0900"
+        example.call
+      end
     end
 
     describe "#permalink_url" do
@@ -593,17 +584,15 @@ describe Article, type: :model do
     end
   end
 
-  describe "an article published just after midnight  JST (+0900)" do
-    before do
+  describe "an article published just after midnight JST (+0900)" do
+    around do |example|
       @time_zone = Time.zone
-      Time.zone = "Tokyo"
-      @a = build(:article)
-      @a.set_permalink
-      @a.published_at = "1 Jan 2013 00:30 +0900"
-    end
-
-    after do
-      Time.zone = @time_zone
+      Time.use_zone "Tokyo" do
+        @a = build(:article)
+        @a.set_permalink
+        @a.published_at = "1 Jan 2013 00:30 +0900"
+        example.call
+      end
     end
 
     describe "#permalink_url" do


### PR DESCRIPTION
When an article is not published, `CommentsController#create` should not allow creation of comments.

- Assign comment to current user if logged in
- Improve spec structure in `Admin::ContentController` specs
- Improve specs for `Article#pings_closed?`
- Use around blocks to switch time zones in article specs
- Restructure specs for `CommentsController#create`
- Do not allow comments on `Article` if not published
- Disallow pings if `Article` is not published
- Replace pointless use of `protected` with `private`
