### PR TITLE
Fix password reset process

### DIFF
--- a/publify_core/.rubocop.yml
+++ b/publify_core/.rubocop.yml
@@ -94,6 +94,10 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/*'
 
+Capybara/FeatureMethods:
+  Exclude:
+    - 'spec/features/**_spec.rb'
+
 # Allow the use of 'and' 'or' in control structures.
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/publify_core/.rubocop_todo.yml
+++ b/publify_core/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Cop supports --auto-correct.
-# Configuration parameters: EnabledMethods.
-Capybara/FeatureMethods:
-  Exclude:
-    - 'spec/features/drafting_articles_spec.rb'
-    - 'spec/features/login_spec.rb'
-    - 'spec/features/setup_spec.rb'
-    - 'spec/features/signup_spec.rb'
-
 # Configuration parameters: IgnoredMethods.
 Metrics/AbcSize:
   Max: 157

--- a/publify_core/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/publify_core/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <% require 'devise/version' %>
-<%# TODO: Link user to blog so we can do @resource.blog
-  blog = Blog.first %>
+<%# TODO: Link user to blog so we can do @resource.blog %>
+<% blog = Blog.first %>
 <p><%= t('.greeting', recipient: @resource.login, default: "Hello #{@resource.login}!") %></p>
 
 <p><%= t('.instruction', default: 'Someone has requested a link to change your password, and you can do this through the link below.') %></p>

--- a/publify_core/app/views/devise/passwords/edit.html.erb
+++ b/publify_core/app/views/devise/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <fieldset>
   <%= f.hidden_field :reset_password_token %>
 

--- a/publify_core/app/views/devise/passwords/new.html.erb
+++ b/publify_core/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <fieldset>
 
     <div class='form-group'>

--- a/publify_core/spec/features/reset_password_spec.rb
+++ b/publify_core/spec/features/reset_password_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Logging in", type: :feature do
+  before do
+    load Rails.root.join("db/seeds.rb")
+    Blog.first.update blog_name: "Awesome!", base_url: "http://www.example.com/"
+    create :user, :as_admin, login: "admin", password: "forget-me"
+  end
+
+  scenario "Admin resets password" do
+    visit "/admin"
+    click_link I18n.t("accounts.lost_my_password")
+
+    fill_in :user_email, with: User.last.email
+    click_button I18n.t("devise.passwords.new.send_me_reset_password_instructions")
+
+    mail = ActionMailer::Base.deliveries.last
+    html = Nokogiri::HTML.parse mail.body.raw_source
+    link = html.at_css "a"
+    url = link.attribute("href").value
+
+    visit url
+
+    fill_in :user_password, with: "a-secret"
+    fill_in :user_password_confirmation, with: "a-secret"
+
+    click_button I18n.t("devise.passwords.edit.change_my_password")
+    expect(page).to have_text I18n.t("devise.passwords.updated")
+  end
+end


### PR DESCRIPTION
- Silence Devise warnings about deprecated `devise_error_messages!` method
- Fix error in password reset mail
- Allow feature specs to use feature spec methods

Fixes #1053.
