### PR TITLE
Bump minimum nokogiri version

### DIFF
--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", ["~> 1.2", ">= 1.2.1"]
   s.add_dependency "mini_magick", ["~> 4.9", ">= 4.9.4"]
   # Force minimum nokogiri version to avoid security issues
-  s.add_dependency "nokogiri", ">= 1.12.5"
+  s.add_dependency "nokogiri", ">= 1.13.2"
   s.add_dependency "rack", ">= 2.2.3"
   s.add_dependency "rails", "~> 5.2.6"
   s.add_dependency "rails_autolink", "~> 1.1.0"


### PR DESCRIPTION
Version 1.13.2 of nokogiri fixes a security issue.
