### PR TITLE
Provide correct article_id input in bulkops form

### DIFF
--- a/publify_core/app/views/admin/feedback/article.html.erb
+++ b/publify_core/app/views/admin/feedback/article.html.erb
@@ -1,12 +1,13 @@
 <% content_for :page_heading do %>
-<h2 class="page-title">
-  <%= t('.comments_for_html', title: @article.title) %>
-</h2>
+  <h2 class="page-title">
+    <%= t('.comments_for_html', title: @article.title) %>
+  </h2>
 <% end %>
 
 <%= form_tag({ action: 'bulkops' }, { class: 'form-inline' }) do %>
 
-  <%= hidden_field 'article_id', @article.id %>
+  <%= hidden_field_tag 'article_id', @article.id %>
+
   <%= render 'button', position: 'top' %>
 
   <br class='clear' />

--- a/publify_core/app/views/admin/feedback/index.html.erb
+++ b/publify_core/app/views/admin/feedback/index.html.erb
@@ -40,6 +40,7 @@
         </td>
       </tr>
     <% end %>
+
     <% @feedback.each do |comment| %>
       <%= render 'feedback', comment: comment %>
     <% end %>


### PR DESCRIPTION
Using `#hidden_field` creates a field for `article_id[article.id]` instead of `article_id`.

Fixes #898.
