### PR TITLE
Do not create article meta description for password-protected articles

### DIFF
--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -166,7 +166,10 @@ class ArticlesController < ContentController
       format.html do
         @comment = Comment.new
         @page_title = this_blog.article_title_template.to_title(@article, this_blog, params)
-        @description = this_blog.article_desc_template.to_title(@article, this_blog, params)
+        if @article.password.blank?
+          @description = this_blog.article_desc_template.
+            to_title(@article, this_blog, params)
+        end
 
         @keywords = @article.tags.map(&:name).join(", ")
         render "articles/#{@article.post_type}"

--- a/publify_core/spec/controllers/articles_controller_spec.rb
+++ b/publify_core/spec/controllers/articles_controller_spec.rb
@@ -483,6 +483,25 @@ RSpec.describe ArticlesController, type: :controller do
           to raise_error ActiveRecord::RecordNotFound
       end
     end
+
+    context "when the article is password protected" do
+      render_views
+
+      let!(:blog) { create(:blog, permalink_format: "/%title%.html") }
+      let!(:article) do
+        create(:article, title: "Secretive", body: "protected foobar", password: "password")
+      end
+
+      it "shows a password form for the article" do
+        get :redirect, params: { from: "secretive.html" }
+        expect(response.body).to have_selector('input[id="article_password"]', count: 1)
+      end
+
+      it "does not include the article body anywhere" do
+        get :redirect, params: { from: "secretive.html" }
+        expect(response.body).not_to include article.body
+      end
+    end
   end
 
   describe "#check_password" do

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -99,11 +99,19 @@ RSpec.describe ArticlesController, type: :controller do
         end
 
         context "when the article is password protected" do
-          let(:article) { create(:article, password: "password") }
+          let(:article) do
+            create(:article, title: "Secretive", body: "protected foobar",
+                             password: "password")
+          end
 
-          it "article alone should be password protected" do
+          it "shows a password form for the article" do
             get :redirect, params: { from: from_param }
             expect(response.body).to have_selector('input[id="article_password"]', count: 1)
+          end
+
+          it "does not include the article body anywhere" do
+            get :redirect, params: { from: from_param }
+            expect(response.body).not_to include article.body
           end
         end
       end


### PR DESCRIPTION
This fixes an issue where the password-protected article text is actually included in a meta tag.
