### PR TITLE
Pull in latest changes from 9-2-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ See the changelogs for the individual engines for more details for releases 9.0 
 * Depend on Ruby 2.5 or above
 * Update other dependencies
 
+## 9.2.8 / 2022-05-14
+
+This release fixes several security issues:
+
+* Disallow comments on draft articles [#1048](https://github.com/publify/publify/pull/1048)
+* Disallow images in comments [#1054](https://github.com/publify/publify/pull/1054)
+* Hide bodies of password-protected articles in search results [#1057](https://github.com/publify/publify/pull/1057)
+* Do not create article meta description for password-protected articles [#1061](https://github.com/publify/publify/pull/1061)
+
+Additionally, it includes the following changes:
+
+* Clean up Feedback validation [#1051](https://github.com/publify/publify/pull/1051)
+* Bump mimimum puma and Rails versions [#1050](https://github.com/publify/publify/pull/1050)
+* Fix password reset process [#1055](https://github.com/publify/publify/pull/1055)
+* Fix password protected article reveal [#1049](https://github.com/publify/publify/pull/1049)
+* Provide correct `article_id` input in bulkops form [#1058](https://github.com/publify/publify/pull/1058)
+* Bump minimum required Rails version [#1062](https://github.com/publify/publify/pull/1062)
+
 ## 9.2.7 / 2022-02-07
 
 This release fixes a security issue:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ["~> 6.1.4"]
+gem "rails", "~> 6.1.4"
 
 gem "mysql2"
 gem "pg"

--- a/publify_amazon_sidebar/CHANGELOG.md
+++ b/publify_amazon_sidebar/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Drop support for Ruby 2.4
 * Update dependencies
 
+## 9.2.8 / 2022-05-14
+
+* Depend on `publify_core` 9.2.7
+
 ## 9.2.7 / 2022-02-07
 
 * Depend on `publify_core` 9.2.7

--- a/publify_amazon_sidebar/lib/publify_amazon_sidebar/version.rb
+++ b/publify_amazon_sidebar/lib/publify_amazon_sidebar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyAmazonSidebar
-  VERSION = "9.2.7"
+  VERSION = "9.2.8"
 end

--- a/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.add_dependency "publify_core", "~> 9.2.7"
+  s.add_dependency "publify_core", "~> 9.2.8"
 
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"

--- a/publify_core/.rubocop.yml
+++ b/publify_core/.rubocop.yml
@@ -97,6 +97,10 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/*'
 
+Capybara/FeatureMethods:
+  Exclude:
+    - 'spec/features/**_spec.rb'
+
 # Allow the use of 'and' 'or' in control structures.
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/publify_core/CHANGELOG.md
+++ b/publify_core/CHANGELOG.md
@@ -9,6 +9,17 @@
 * Remove support for Textile as a text format
 * Replace BlueCloth with CommonMarker for Markdown processing
 
+## 9.2.8 / 2022-05-14
+
+* Fix password protected article reveal [#1049](https://github.com/publify/publify/pull/1049)
+* Disallow comments on draft articles [#1048](https://github.com/publify/publify/pull/1048)
+* Clean up Feedback validation [#1051](https://github.com/publify/publify/pull/1051)
+* Disallow images in comments [#1054](https://github.com/publify/publify/pull/1054)
+* Fix password reset process [#1055](https://github.com/publify/publify/pull/1055)
+* Hide bodies of password-protected articles in search results [#1057](https://github.com/publify/publify/pull/1057)
+* Provide correct `article_id` input in bulkops form [#1058](https://github.com/publify/publify/pull/1058)
+* Do not create article meta description for password-protected articles [#1061](https://github.com/publify/publify/pull/1061)
+
 ## 9.2.7 / 2022-02-07
 
 * Fix setting the article password from the Admin [#1044](https://github.com/publify/publify/pull/1044)

--- a/publify_core/Manifest.txt
+++ b/publify_core/Manifest.txt
@@ -27,6 +27,7 @@ app/assets/javascripts/bootstrap/dropdown.js
 app/assets/javascripts/bootstrap/modal.js
 app/assets/javascripts/bootstrap/tab.js
 app/assets/javascripts/bootstrap/transition.js
+app/assets/javascripts/check_password.js
 app/assets/javascripts/cookies.js
 app/assets/javascripts/datetimepicker.js
 app/assets/javascripts/lang/da_DK.js

--- a/publify_core/app/assets/javascripts/check_password.js
+++ b/publify_core/app/assets/javascripts/check_password.js
@@ -1,0 +1,9 @@
+// Show and hide spinners on Ajax requests.
+$(document).ready(function() {
+  $('form.check_password').on('ajax:complete',
+    function(evt, xhr, stat) {
+      var form = evt.currentTarget;
+      var elem = document.getElementById(form.dataset["update"]);
+      elem.outerHTML = xhr.responseText;
+    })
+});

--- a/publify_core/app/assets/javascripts/publify.js
+++ b/publify_core/app/assets/javascripts/publify.js
@@ -7,5 +7,6 @@
 //= require jquery_ujs
 //= require lightbox
 //= require observe
+//= require check_password
 //
 //= require_self

--- a/publify_core/app/controllers/admin/articles_controller.rb
+++ b/publify_core/app/controllers/admin/articles_controller.rb
@@ -131,7 +131,7 @@ class Admin::ArticlesController < Admin::BaseController
     end
   end
 
-  protected
+  private
 
   def fetch_fresh_or_existing_draft_for_article
     return unless @article.published? && @article.id
@@ -145,8 +145,6 @@ class Admin::ArticlesController < Admin::BaseController
   end
 
   attr_accessor :resources, :resource
-
-  private
 
   def load_resources
     @post_types = PostType.all

--- a/publify_core/app/controllers/articles_controller.rb
+++ b/publify_core/app/controllers/articles_controller.rb
@@ -166,7 +166,10 @@ class ArticlesController < ContentController
       format.html do
         @comment = Comment.new
         @page_title = this_blog.article_title_template.to_title(@article, this_blog, params)
-        @description = this_blog.article_desc_template.to_title(@article, this_blog, params)
+        if @article.password.blank?
+          @description = this_blog.article_desc_template.
+            to_title(@article, this_blog, params)
+        end
 
         @keywords = @article.tags.map(&:name).join(", ")
         render "articles/#{@article.post_type}"

--- a/publify_core/app/controllers/comments_controller.rb
+++ b/publify_core/app/controllers/comments_controller.rb
@@ -7,11 +7,6 @@ class CommentsController < BaseController
     options = new_comment_defaults.merge comment_params.to_h
     @comment = @article.add_comment(options)
 
-    unless current_user.nil? || session[:user_id].nil?
-      # maybe useless, but who knows ?
-      @comment.user_id = current_user.id if current_user.id == session[:user_id]
-    end
-
     remember_author_info_for @comment
 
     partial = "/articles/comment_failed"
@@ -33,7 +28,7 @@ class CommentsController < BaseController
     @comment = @article.comments.build(comment_params)
   end
 
-  protected
+  private
 
   def recaptcha_ok_for?(comment)
     use_recaptcha = comment.blog.use_recaptcha
@@ -43,7 +38,7 @@ class CommentsController < BaseController
   def new_comment_defaults
     { ip: request.remote_ip,
       author: "Anonymous",
-      user: @current_user,
+      user: current_user,
       user_agent: request.env["HTTP_USER_AGENT"],
       referrer: request.env["HTTP_REFERER"],
       permalink: @article.permalink_url }.stringify_keys

--- a/publify_core/app/models/article.rb
+++ b/publify_core/app/models/article.rb
@@ -204,7 +204,7 @@ class Article < Content
   end
 
   def comments_closed?
-    !(allow_comments? && in_feedback_window?)
+    !(allow_comments? && published? && in_feedback_window?)
   end
 
   def html_urls
@@ -216,7 +216,7 @@ class Article < Content
   end
 
   def pings_closed?
-    !(allow_pings? && in_feedback_window?)
+    !(allow_pings? && published? && in_feedback_window?)
   end
 
   # check if time to comment is open or not

--- a/publify_core/app/models/comment.rb
+++ b/publify_core/app/models/comment.rb
@@ -38,13 +38,21 @@ class Comment < Feedback
     really_send_notifications
   end
 
-  protected
+  private
 
   def article_allows_feedback?
     return true if article.allow_comments?
 
     errors.add(:article, "Article is not open to comments")
     false
+  end
+
+  def blog_allows_feedback?
+    true
+  end
+
+  def check_article_closed_for_feedback
+    errors.add(:article, "Comment are closed") if article.comments_closed?
   end
 
   def originator

--- a/publify_core/app/models/trackback.rb
+++ b/publify_core/app/models/trackback.rb
@@ -24,8 +24,12 @@ class Trackback < Feedback
   def blog_allows_feedback?
     return true unless blog.global_pings_disable
 
-    errors.add(:article, "Pings are disabled")
+    errors.add(:base, "Pings are disabled")
     false
+  end
+
+  def check_article_closed_for_feedback
+    errors.add(:article, "Pings are closed") if article.pings_closed?
   end
 
   def originator

--- a/publify_core/app/views/admin/feedback/article.html.erb
+++ b/publify_core/app/views/admin/feedback/article.html.erb
@@ -6,7 +6,7 @@
 
 <%= form_tag({ action: 'bulkops' }, { class: 'form-inline' }) do %>
 
-  <%= hidden_field 'article_id', @article.id %>
+  <%= hidden_field_tag 'article_id', @article.id %>
 
   <% if @feedback.any? %>
     <%= render 'button', position: 'top' %>

--- a/publify_core/app/views/articles/_password_form.html.erb
+++ b/publify_core/app/views/articles/_password_form.html.erb
@@ -1,10 +1,8 @@
 <div id='content-<%= article.id %>'>
   <p>This post is password protected. Please fill in your password or login to view the content</p>
-  <%= form_for(article, remote: true,
-                        url: { controller: 'articles', action: 'check_password' },
-                        update: "content-#{article.id}") do |f| %>
+  <%= form_tag(check_password_url, remote: true, class: "check_password", data: { update: "content-#{article.id}" }) do %>
     <%= password_field(:article, :password) %>
-    <input type='hidden' name='article[id]' value='<%= article.id %>' />
+    <%= hidden_field(:article, :id) %>
     <%= submit_tag(t('.submit') + '!', name: 'check_password') %>
   <% end %>
 </div>

--- a/publify_core/app/views/articles/search.html.erb
+++ b/publify_core/app/views/articles/search.html.erb
@@ -1,7 +1,9 @@
 <% for article in @articles %>
  <div class="post">
    <h2><%= link_to_permalink article, article.title %></h2>
-   <%= article.html(:body).gsub(%r{</?[^>]*>}, '').slice(0..300) %>...
+   <% if article.password.blank? %>
+     <%= article.html(:body).gsub(%r{</?[^>]*>}, '').slice(0..300) %>...
+   <% end %>
   </div>
 <% end %>
 

--- a/publify_core/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/publify_core/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,6 @@
 <% require 'devise/version' %>
-<%# TODO: Link user to blog so we can do @resource.blog
-  blog = Blog.first %>
+<%# TODO: Link user to blog so we can do @resource.blog %>
+<% blog = Blog.first %>
 <p><%= t('.greeting', recipient: @resource.login, default: "Hello #{@resource.login}!") %></p>
 
 <p><%= t('.instruction', default: 'Someone has requested a link to change your password, and you can do this through the link below.') %></p>

--- a/publify_core/app/views/devise/passwords/edit.html.erb
+++ b/publify_core/app/views/devise/passwords/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <fieldset>
   <%= f.hidden_field :reset_password_token %>
 

--- a/publify_core/app/views/devise/passwords/new.html.erb
+++ b/publify_core/app/views/devise/passwords/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
   <fieldset>
 
     <div class='form-group'>

--- a/publify_core/config/routes.rb
+++ b/publify_core/config/routes.rb
@@ -36,9 +36,10 @@ Rails.application.routes.draw do
   get "/pages/*name", to: "articles#view_page", format: false
   get "previews(/:id)", to: "articles#preview", format: false
   get "previews_pages(/:id)", to: "articles#preview_page", format: false
-  get "check_password", to: "articles#check_password", format: false
   get "articles/markup_help/:id", to: "articles#markup_help", format: false
   get "articles/tag", to: "articles#tag", format: false
+
+  post "check_password", to: "articles#check_password", format: false
 
   # SetupController
   get "/setup", to: "setup#index", format: false

--- a/publify_core/lib/publify_core/version.rb
+++ b/publify_core/lib/publify_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyCore
-  VERSION = "9.2.7"
+  VERSION = "9.2.8"
 end

--- a/publify_core/lib/spam_protection.rb
+++ b/publify_core/lib/spam_protection.rb
@@ -31,7 +31,7 @@ class SpamProtection
     end
   end
 
-  protected
+  private
 
   def scan_ip(ip_address)
     logger.info("[SP] Scanning IP #{ip_address}")

--- a/publify_core/spec/controllers/admin/articles_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/articles_controller_spec.rb
@@ -43,27 +43,23 @@ RSpec.describe Admin::ArticlesController, type: :controller do
         create(:article, state: "publication_pending", published_at: "2020-01-01")
       end
 
-      before { get :index, params: { search: state } }
+      it "returns draft articles when drafts is specified" do
+        get :index, params: { search: { state: "drafts" } }
 
-      context "draft only" do
-        let(:state) { { state: "drafts" } }
-
-        it { expect(assigns(:articles)).to eq([draft_article]) }
+        expect(assigns(:articles)).to eq([draft_article])
       end
 
-      context "publication_pending only" do
-        let(:state) { { state: "pending" } }
+      it "returns pending articles when pending is specified" do
+        get :index, params: { search: { state: "pending" } }
 
-        it { expect(assigns(:articles)).to eq([pending_article]) }
+        expect(assigns(:articles)).to eq([pending_article])
       end
 
-      context "with a bad state" do
-        let(:state) { { state: "3vI1 1337 h4x0r" } }
+      it "returns all states when called with a bad state" do
+        get :index, params: { search: { state: "3vI1 1337 h4x0r" } }
 
-        it "returns all states" do
-          expect(assigns(:articles).sort).
-            to eq([article, pending_article, draft_article].sort)
-        end
+        expect(assigns(:articles).sort).
+          to eq([article, pending_article, draft_article].sort)
       end
     end
   end

--- a/publify_core/spec/controllers/admin/feedback_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/feedback_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "index" do
+    describe "#index" do
       let!(:spam) { create(:spam_comment) }
       let!(:unapproved) { create(:unconfirmed_comment) }
       let!(:presumed_ham) { create(:presumed_ham_comment) }
@@ -108,45 +108,57 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "article action" do
+    describe "#article" do
+      # render_template
       let(:article) { create(:article) }
       let!(:ham) { create(:comment, article: article) }
       let!(:spam) { create(:comment, article: article, state: "spam") }
 
-      def should_success_with_article_view(response)
-        expect(response).to be_successful
-        expect(response).to render_template("article")
-      end
-
       it "sees all feedback on one article" do
         get :article, params: { id: article.id }
-        should_success_with_article_view(response)
-        expect(assigns(:article)).to eq(article)
-        expect(assigns(:feedback)).to match_array [ham, spam]
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to render_template("article")
+          expect(assigns(:article)).to eq(article)
+          expect(assigns(:feedback)).to match_array [ham, spam]
+        end
+      end
+
+      it "includes hidden article id field in bulkops form" do
+        get :article, params: { id: article.id }
+        expect(response.body).
+          to have_css("form[action='/admin/feedback/bulkops'] input[name=article_id]",
+                      visible: :hidden)
       end
 
       it "sees only spam feedback on one article" do
         get :article, params: { id: article.id, spam: "y" }
-        should_success_with_article_view(response)
-        expect(assigns(:article)).to eq(article)
-        expect(assigns(:feedback)).to match_array [spam]
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to render_template("article")
+          expect(assigns(:article)).to eq(article)
+          expect(assigns(:feedback)).to match_array [spam]
+        end
       end
 
       it "sees only ham feedback on one article" do
         get :article, params: { id: article.id, ham: "y" }
-        should_success_with_article_view(response)
-        expect(assigns(:article)).to eq(article)
-        expect(assigns(:feedback)).to match_array [ham]
+        aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to render_template("article")
+          expect(assigns(:article)).to eq(article)
+          expect(assigns(:feedback)).to match_array [ham]
+        end
       end
 
-      it "redirect_toes index if bad article id" do
+      it "renders error if bad article id" do
         expect do
           get :article, params: { id: 102_302 }
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
-    describe "create action" do
+    describe "#create" do
       def base_comment(options = {})
         { "body" => "a new comment", "author" => "Me", "url" => "https://bar.com/",
           "email" => "foo@bar.com" }.merge(options)
@@ -193,7 +205,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "edit action" do
+    describe "#edit" do
       it "renders edit form" do
         article = create(:article)
         comment = create(:comment, article: article)
@@ -205,7 +217,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "update action" do
+    describe "#update" do
       it "updates comment if post request" do
         article = create(:article)
         comment = create(:comment, article: article)
@@ -240,7 +252,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       sign_in publisher
     end
 
-    describe "destroy action" do
+    describe "#destroy" do
       it_behaves_like "destroy feedback with feedback from own article"
 
       it "does not destroy feedback doesn't own" do
@@ -253,7 +265,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "edit action" do
+    describe "#edit" do
       it "does not edit comment no own article" do
         get "edit", params: { id: feedback_from_not_own_article.id }
         expect(response).to redirect_to(action: "index")
@@ -268,7 +280,7 @@ RSpec.describe Admin::FeedbackController, type: :controller do
       end
     end
 
-    describe "update action" do
+    describe "#update" do
       it "updates comment if own article" do
         post "update", params: { id: feedback_from_own_article.id,
                                  comment: { author: "Bob Foo2",
@@ -292,9 +304,14 @@ RSpec.describe Admin::FeedbackController, type: :controller do
     end
 
     describe "#bulkops action" do
-      it "redirect to index" do
+      it "redirects to index" do
         post :bulkops, params: { bulkop_top: "destroy all spam" }
         expect(@response).to redirect_to(action: "index")
+      end
+
+      it "redirects to article when id is given" do
+        post :bulkops, params: { article_id: article.id, bulkop_top: "destroy all spam" }
+        expect(@response).to redirect_to article_admin_feedback_url(article)
       end
 
       it "delete all spam" do

--- a/publify_core/spec/controllers/comments_controller_spec.rb
+++ b/publify_core/spec/controllers/comments_controller_spec.rb
@@ -5,52 +5,73 @@ require "rails_helper"
 RSpec.describe CommentsController, type: :controller do
   let!(:blog) { create(:blog) }
   let(:article) { create(:article) }
+  let(:user) { create(:user) }
   let(:comment_params) do
     { body: "content", author: "bob", email: "bob@home", url: "http://bobs.home/" }
   end
 
   describe "#create" do
-    context "when using regular post" do
-      before do
-        post :create, params: { comment: comment_params, article_id: article.id }
-      end
+    render_views
 
-      it "creates a comment on the specified article" do
-        aggregate_failures do
-          expect(article.comments.size).to eq(1)
-          comment = article.comments.last
-          expect(comment.author).to eq("bob")
-          expect(comment.body).to eq("content")
-          expect(comment.email).to eq("bob@home")
-          expect(comment.url).to eq("http://bobs.home/")
-        end
-      end
-
-      it "remembers author info in cookies" do
-        aggregate_failures do
-          expect(cookies["author"]).to eq("bob")
-          expect(cookies["gravatar_id"]).to eq(Digest::MD5.hexdigest("bob@home"))
-          expect(cookies["url"]).to eq("http://bobs.home/")
-        end
-      end
-
-      it "redirects to the article" do
-        expect(response).to redirect_to article.permalink_url
+    it "creates a comment on the specified article" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
+        expect(article.comments.size).to eq(1)
+        comment = article.comments.last
+        expect(comment.author).to eq("bob")
+        expect(comment.body).to eq("content")
+        expect(comment.email).to eq("bob@home")
+        expect(comment.url).to eq("http://bobs.home/")
       end
     end
 
-    context "when using xhr post" do
-      before do
-        post :create, xhr: true, params: { comment: comment_params, article_id: article.id }
+    it "remembers author info in cookies" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
+        expect(cookies["author"]).to eq("bob")
+        expect(cookies["gravatar_id"]).to eq(Digest::MD5.hexdigest("bob@home"))
+        expect(cookies["url"]).to eq("http://bobs.home/")
       end
+    end
 
-      it "assigns the created comment for rendering" do
-        expect(assigns[:comment]).to eq article.comments.last
-      end
+    it "sets the user if logged in" do
+      sign_in user
+      post :create, params: { comment: comment_params, article_id: article.id }
+      comment = article.comments.last
+      expect(comment.user).to eq user
+    end
 
-      it "renders the comment partial" do
+    it "assigns the created comment" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      expect(assigns[:comment]).to eq article.comments.last
+    end
+
+    it "redirects to the article when using regular post" do
+      post :create, params: { comment: comment_params, article_id: article.id }
+      expect(response).to redirect_to article.permalink_url
+    end
+
+    it "renders the comment when using xhr post" do
+      post :create, xhr: true, params: { comment: comment_params, article_id: article.id }
+      aggregate_failures do
         expect(response).to render_template("articles/comment")
+        expect(response.body).to have_text "content"
       end
+    end
+
+    it "does not allow commenting if article does not allow comments" do
+      no_comments = create(:article, allow_comments: false)
+      expect do
+        post :create, xhr: true, params: { comment: comment_params,
+                                           article_id: no_comments.id }
+      end.not_to change(no_comments.comments, :count)
+    end
+
+    it "does not allow commenting if article is draft" do
+      draft = create(:article, state: "draft")
+      expect do
+        post :create, xhr: true, params: { comment: comment_params, article_id: draft.id }
+      end.not_to change(draft.comments, :count)
     end
   end
 

--- a/publify_core/spec/features/reset_password_spec.rb
+++ b/publify_core/spec/features/reset_password_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Logging in", type: :feature do
+  before do
+    load Rails.root.join("db/seeds.rb")
+    Blog.first.update blog_name: "Awesome!", base_url: "http://www.example.com/"
+    create :user, :as_admin, login: "admin", password: "forget-me"
+  end
+
+  scenario "Admin resets password" do
+    visit "/admin"
+    click_link I18n.t("accounts.lost_my_password")
+
+    fill_in :user_email, with: User.last.email
+    click_button I18n.t("devise.passwords.new.send_me_reset_password_instructions")
+
+    mail = ActionMailer::Base.deliveries.last
+    html = Nokogiri::HTML.parse mail.body.raw_source
+    link = html.at_css "a"
+    url = link.attribute("href").value
+
+    visit url
+
+    fill_in :user_password, with: "a-secret"
+    fill_in :user_password_confirmation, with: "a-secret"
+
+    click_button I18n.t("devise.passwords.edit.change_my_password")
+    expect(page).to have_text I18n.t("devise.passwords.updated")
+  end
+end

--- a/publify_core/spec/routing/articles_routing_spec.rb
+++ b/publify_core/spec/routing/articles_routing_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ArticlesController, type: :routing do
-  describe "routing" do
+  describe "routing for #index" do
     it "recognizes and generates #index" do
       expect(get: "/").to route_to(controller: "articles", action: "index")
     end
@@ -16,6 +16,13 @@ RSpec.describe ArticlesController, type: :routing do
     it "recognizes and generates #index with atom format" do
       expect(get: "/articles.atom").
         to route_to(controller: "articles", action: "index", format: "atom")
+    end
+  end
+
+  describe "routing for #check_password" do
+    it "recognizes and generates POST on #check_password" do
+      expect(post: "/check_password").
+        to route_to(controller: "articles", action: "check_password")
     end
   end
 

--- a/publify_textfilter_code/CHANGELOG.md
+++ b/publify_textfilter_code/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Drop support for Ruby 2.4
 * Update dependencies
 
+## 9.2.8 / 2022-05-14
+
+* Depend on `publify_core` 9.2.8
+
 ## 9.2.7 / 2022-02-07
 
 * Depend on `publify_core` 9.2.7

--- a/publify_textfilter_code/lib/publify_textfilter_code/version.rb
+++ b/publify_textfilter_code/lib/publify_textfilter_code/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyTextfilterCode
-  VERSION = "9.2.7"
+  VERSION = "9.2.8"
 end

--- a/publify_textfilter_code/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code/publify_textfilter_code.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "coderay", "~> 1.1.0"
   s.add_dependency "htmlentities", "~> 4.3"
-  s.add_dependency "publify_core", "~> 9.2.7"
+  s.add_dependency "publify_core", "~> 9.2.8"
 
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -99,11 +99,19 @@ RSpec.describe ArticlesController, type: :controller do
         end
 
         context "when the article is password protected" do
-          let(:article) { create(:article, password: "password") }
+          let(:article) do
+            create(:article, title: "Secretive", body: "protected foobar",
+                             password: "password")
+          end
 
-          it "article alone should be password protected" do
+          it "shows a password form for the article" do
             get :redirect, params: { from: from_param }
             expect(response.body).to have_selector('input[id="article_password"]', count: 1)
+          end
+
+          it "does not include the article body anywhere" do
+            get :redirect, params: { from: from_param }
+            expect(response.body).not_to include article.body
           end
         end
       end
@@ -308,16 +316,16 @@ RSpec.describe ArticlesController, type: :controller do
         let!(:article) { create(:article, password: "password") }
 
         it "shows article when given correct password" do
-          get :check_password, xhr: true,
-                               params: { article: { id: article.id,
-                                                    password: article.password } }
+          post :check_password, xhr: true,
+                                params: { article: { id: article.id,
+                                                     password: article.password } }
           expect(response.body).not_to have_selector('input[id="article_password"]')
         end
 
         it "shows password form when given incorrect password" do
-          get :check_password, xhr: true,
-                               params: { article: { id: article.id,
-                                                    password: "wrong password" } }
+          post :check_password, xhr: true,
+                                params: { article: { id: article.id,
+                                                     password: "wrong password" } }
           expect(response.body).to have_selector('input[id="article_password"]')
         end
       end


### PR DESCRIPTION
- Consistently use POST method for check_password action
- Bump mimimum puma and Rails versions
- Fix password protected article form response handling
- Assign comment to current user if logged in
- Improve spec structure in Admin::ContentController specs
- Improve specs for Article#pings_closed?
- Use around blocks to switch time zones in article specs
- Restructure specs for CommentsController#create
- Do not allow comments on Article if not published
- Disallow pings if Article is not published
- Replace pointless use of 'protected' with 'private'
- Clean up Feedback validation
- Unify specs for disallowing script tags in comments
- Do not allow images in comments
- Silence Devise warnings about deprecated devise_error_messages! method
- Fix error in password reset mail
- Allow feature specs to use feature spec methods
- Hide bodies of password-protected articles in search results
- Provide correct article_id input in bulkops form
- Do not create article meta description for password-protected articles
- Bump minimum required Rails version
- Prepare version 9.2.8 for release
