### PR TITLE
Pull in latest changes from 9-2-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ See the changelogs for the individual engines for more details for releases 9.0 
 * Depend on Ruby 2.5 or above
 * Update other dependencies
 
+## 9.2.9 / 2022-05-22
+
+This release fixes two security issues:
+
+* Fix admin article access control [#1065](https://github.com/publify/publify/pull/1065)
+* Refuse html files as resources even if declared to be plain text [#1066](https://github.com/publify/publify/pull/1066)
+
 ## 9.2.8 / 2022-05-14
 
 This release fixes several security issues:

--- a/publify_amazon_sidebar/CHANGELOG.md
+++ b/publify_amazon_sidebar/CHANGELOG.md
@@ -5,9 +5,13 @@
 * Drop support for Ruby 2.4
 * Update dependencies
 
+## 9.2.9 / 2022-05-22
+
+* Depend on `publify_core` 9.2.9
+
 ## 9.2.8 / 2022-05-14
 
-* Depend on `publify_core` 9.2.7
+* Depend on `publify_core` 9.2.8
 
 ## 9.2.7 / 2022-02-07
 

--- a/publify_amazon_sidebar/lib/publify_amazon_sidebar/version.rb
+++ b/publify_amazon_sidebar/lib/publify_amazon_sidebar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyAmazonSidebar
-  VERSION = "9.2.8"
+  VERSION = "9.2.9"
 end

--- a/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.add_dependency "publify_core", "~> 9.2.8"
+  s.add_dependency "publify_core", "~> 9.2.9"
 
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"

--- a/publify_core/CHANGELOG.md
+++ b/publify_core/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Remove support for Textile as a text format
 * Replace BlueCloth with CommonMarker for Markdown processing
 
+## 9.2.9 / 2022-05-22
+
+* Fix admin article access control [#1065](https://github.com/publify/publify/pull/1065)
+* Refuse html files as resources even if declared to be plain text [#1066](https://github.com/publify/publify/pull/1066)
+
 ## 9.2.8 / 2022-05-14
 
 * Fix password protected article reveal [#1049](https://github.com/publify/publify/pull/1049)

--- a/publify_core/app/controllers/admin/articles_controller.rb
+++ b/publify_core/app/controllers/admin/articles_controller.rb
@@ -58,9 +58,9 @@ class Admin::ArticlesController < Admin::BaseController
   end
 
   def update
-    return unless access_granted?(params[:id])
+    id = params[:id]
+    return unless access_granted?(id)
 
-    id = params[:article][:id] || params[:id]
     @article = Article.find(id)
 
     if params[:article][:draft]
@@ -101,6 +101,7 @@ class Admin::ArticlesController < Admin::BaseController
     return false unless request.xhr?
 
     id = params[:article][:id] || params[:id]
+    return if id && !access_granted?(id)
 
     article_factory = Article::Factory.new(this_blog, current_user)
     @article = article_factory.get_or_build_from(id)

--- a/publify_core/lib/publify_core/version.rb
+++ b/publify_core/lib/publify_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyCore
-  VERSION = "9.2.8"
+  VERSION = "9.2.9"
 end

--- a/publify_core/spec/controllers/admin/resources_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/resources_controller_spec.rb
@@ -187,6 +187,30 @@ RSpec.describe Admin::ResourcesController, type: :controller do
       end
     end
 
+    context "when attempting to upload an html file as text/plain" do
+      let(:upload) { file_upload("just_some.html", "text/plain") }
+
+      it "does not create a new Resource" do
+        expect { post :upload, params: { upload: upload } }.
+          not_to change(Resource, :count)
+      end
+
+      it "warns the user they can't upload this type of file" do
+        post :upload, params: { upload: upload }
+        result = assigns(:up)
+        expect(result.errors[:upload]).
+          to match_array ["has MIME type mismatch", "can't be blank"]
+      end
+
+      it "sets the flash to failure" do
+        post :upload, params: { upload: upload }
+        aggregate_failures do
+          expect(flash[:success]).to be_nil
+          expect(flash[:warning]).not_to be_nil
+        end
+      end
+    end
+
     context "when uploading nothing" do
       it "does not create a new Resource" do
         expect { post :upload }.

--- a/publify_textfilter_code/CHANGELOG.md
+++ b/publify_textfilter_code/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Drop support for Ruby 2.4
 * Update dependencies
 
+## 9.2.9 / 2022-05-22
+
+* Depend on `publify_core` 9.2.9
+
 ## 9.2.8 / 2022-05-14
 
 * Depend on `publify_core` 9.2.8

--- a/publify_textfilter_code/lib/publify_textfilter_code/version.rb
+++ b/publify_textfilter_code/lib/publify_textfilter_code/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PublifyTextfilterCode
-  VERSION = "9.2.8"
+  VERSION = "9.2.9"
 end

--- a/publify_textfilter_code/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code/publify_textfilter_code.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "coderay", "~> 1.1.0"
   s.add_dependency "htmlentities", "~> 4.3"
-  s.add_dependency "publify_core", "~> 9.2.8"
+  s.add_dependency "publify_core", "~> 9.2.9"
 
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"


### PR DESCRIPTION
- Use only the main id parameter to find Article to update
- Only allow publisher to autosave their own articles
- Refuse html files as resources even if declared to be plain text
- Prepare version 9.2.9 for release
