### PR TITLE
Limit length of settings values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :test do
   gem "feedjira", "~> 3.2"
   gem "launchy", "~> 2.4"
   gem "rails-controller-testing", "~> 1.0.1"
+  gem "shoulda-matchers", "~> 4.5"
   gem "timecop", "~> 0.9.1"
   gem "webmock", "~> 3.3"
 end

--- a/publify_core/app/models/blog.rb
+++ b/publify_core/app/models/blog.rb
@@ -71,11 +71,11 @@ class Blog < ApplicationRecord
   setting :image_medium_size, :integer, 600
 
   # SEO
-  setting :meta_description, :string, ""
+  setting :meta_description, :text, ""
   setting :meta_keywords, :string, ""
   setting :google_analytics, :string, ""
   setting :rss_description, :boolean, false
-  setting :rss_description_text, :string, <<-HTML.strip_heredoc
+  setting :rss_description_text, :text, <<-HTML.strip_heredoc
     <hr />
     <p><small>Original article written by %author% and published on <a href='%blog_url%'>%blog_name%</a>
     | <a href='%permalink_url%'>direct link to this article</a>
@@ -83,8 +83,8 @@ class Blog < ApplicationRecord
       it has been illegally reproduced and without proper authorization.</small></p>
   HTML
   setting :permalink_format, :string, "/%year%/%month%/%day%/%title%"
-  setting :robots, :string, 'User-agent: *\nAllow: /\nDisallow: /admin\n'
-  setting :humans, :string, <<-TEXT.strip_heredoc
+  setting :robots, :text, 'User-agent: *\nAllow: /\nDisallow: /admin\n'
+  setting :humans, :text, <<-TEXT.strip_heredoc
     /* TEAM */
     Your title: Your name.
     Site: email, link to a contact form, etc.

--- a/publify_core/app/models/config_manager.rb
+++ b/publify_core/app/models/config_manager.rb
@@ -19,7 +19,10 @@ module ConfigManager
       item.ruby_type = type
       item.default = default
       fields[name.to_s] = item
-      add_setting_accessor(item)
+
+      add_setting_reader(item)
+      add_setting_writer(item)
+      add_setting_validation(item)
     end
 
     def default_for(key)
@@ -27,11 +30,6 @@ module ConfigManager
     end
 
     private
-
-    def add_setting_accessor(item)
-      add_setting_reader(item)
-      add_setting_writer(item)
-    end
 
     def add_setting_reader(item)
       send(:define_method, item.name) do
@@ -53,6 +51,15 @@ module ConfigManager
         retval
       end
     end
+
+    def add_setting_validation(item)
+      case item.ruby_type
+      when :string
+        validates item.name, length: { maximum: 256 }
+      when :text
+        validates item.name, length: { maximum: 2048 }
+      end
+    end
   end
 
   def canonicalize(key, value)
@@ -60,7 +67,7 @@ module ConfigManager
   end
 
   class Item
-    VALID_TYPES = [:boolean, :integer, :string].freeze
+    VALID_TYPES = [:boolean, :integer, :string, :text].freeze
 
     attr_accessor :name, :ruby_type, :default
 
@@ -75,7 +82,7 @@ module ConfigManager
         end
       when :integer
         value.to_i
-      when :string
+      when :string, :text
         value.to_s
       end
     end

--- a/publify_core/app/models/config_manager.rb
+++ b/publify_core/app/models/config_manager.rb
@@ -12,6 +12,8 @@ module ConfigManager
     end
 
     def setting(name, type = :object, default = nil)
+      raise "Invalid type: #{type}" unless Item::VALID_TYPES.include? type
+
       item = Item.new
       item.name = name.to_s
       item.ruby_type = type
@@ -58,6 +60,8 @@ module ConfigManager
   end
 
   class Item
+    VALID_TYPES = [:boolean, :integer, :string].freeze
+
     attr_accessor :name, :ruby_type, :default
 
     def canonicalize(value)
@@ -73,10 +77,6 @@ module ConfigManager
         value.to_i
       when :string
         value.to_s
-      when :yaml
-        value.to_yaml
-      else
-        value
       end
     end
   end

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rails-controller-testing", "~> 1.0.1"
   s.add_development_dependency "rspec-rails", "~> 4.0"
+  s.add_development_dependency "shoulda-matchers", "~> 4.5"
   s.add_development_dependency "simplecov", "~> 0.19.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "timecop", "~> 0.9.1"

--- a/publify_core/spec/lib/theme_spec.rb
+++ b/publify_core/spec/lib/theme_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe Theme, type: :model do
   let(:blog) { build_stubbed :blog }
   let(:default_theme) { blog.current_theme }
+  let(:engine_root) { PublifyCore::Engine.instance.root }
 
   describe "#layout" do
     it 'returns "layouts/default" by default' do

--- a/publify_core/spec/models/blog_spec.rb
+++ b/publify_core/spec/models/blog_spec.rb
@@ -110,6 +110,30 @@ describe Blog, type: :model do
     end
   end
 
+  describe "validations" do
+    let(:blog) { described_class.new }
+
+    it "requires blog name to not be too long" do
+      expect(blog).to validate_length_of(:blog_name).is_at_most(256)
+    end
+
+    it "allows up to 2048 characters for the rss_description_text setting" do
+      expect(blog).to validate_length_of(:rss_description_text).is_at_most(2048)
+    end
+
+    it "allows up to 2048 characters for the robots setting" do
+      expect(blog).to validate_length_of(:robots).is_at_most(2048)
+    end
+
+    it "allows up to 2048 characters for the humans setting" do
+      expect(blog).to validate_length_of(:humans).is_at_most(2048)
+    end
+
+    it "allows up to 2048 characters for the meta_description setting" do
+      expect(blog).to validate_length_of(:meta_description).is_at_most(2048)
+    end
+  end
+
   describe ".meta_keywords" do
     it "return empty string when nothing" do
       blog = described_class.new

--- a/publify_core/spec/models/user_spec.rb
+++ b/publify_core/spec/models/user_spec.rb
@@ -105,6 +105,18 @@ describe User, type: :model do
     end
   end
 
+  describe "validations" do
+    let(:user) { described_class.new }
+
+    it "requires first name to not be too long" do
+      expect(user).to validate_length_of(:firstname).is_at_most(256)
+    end
+
+    it "requires last name to not be too long" do
+      expect(user).to validate_length_of(:lastname).is_at_most(256)
+    end
+  end
+
   describe "#initialize" do
     it "accepts a settings field in its parameter hash" do
       described_class.new("firstname" => "foo")

--- a/publify_core/spec/rails_helper.rb
+++ b/publify_core/spec/rails_helper.rb
@@ -15,6 +15,7 @@ require "publify_core/testing_support/feed_assertions"
 require "publify_core/testing_support/upload_fixtures"
 require "capybara/rspec"
 require "webmock/rspec"
+require "shoulda-matchers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -92,4 +93,11 @@ end
 
 def engine_root
   PublifyCore::Engine.instance.root
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/publify_core/spec/rails_helper.rb
+++ b/publify_core/spec/rails_helper.rb
@@ -91,10 +91,6 @@ RSpec.configure do |config|
   end
 end
 
-def engine_root
-  PublifyCore::Engine.instance.root
-end
-
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec


### PR DESCRIPTION
- Limit allowed setting types
- Add shoulda-matchers for testing validations
- Move engine_root spec helper method to a let definition
- Maximize string settings at 256 characters
