### PR TITLE
Validate lengths of string attributes

### DIFF
--- a/publify_core/Manifest.txt
+++ b/publify_core/Manifest.txt
@@ -160,6 +160,7 @@ app/models/article.rb
 app/models/article/factory.rb
 app/models/blog.rb
 app/models/comment.rb
+app/models/concerns/string_length_limit.rb
 app/models/config_manager.rb
 app/models/content.rb
 app/models/content_base.rb

--- a/publify_core/app/models/blog.rb
+++ b/publify_core/app/models/blog.rb
@@ -9,6 +9,8 @@
 #
 class Blog < ApplicationRecord
   include ConfigManager
+  include StringLengthLimit
+
   include Rails.application.routes.url_helpers
 
   has_many :contents
@@ -139,6 +141,7 @@ class Blog < ApplicationRecord
 
   validate :permalink_has_identifier
   # validates :base_url, presence: true
+  validates_default_string_length :base_url
 
   # Find the Blog that matches a specific base URL. If no Blog object is found
   # that matches, then grab the first blog. If *that* fails, then create a new

--- a/publify_core/app/models/comment.rb
+++ b/publify_core/app/models/comment.rb
@@ -41,18 +41,15 @@ class Comment < Feedback
   private
 
   def article_allows_feedback?
-    return true if article.allow_comments?
-
-    errors.add(:article, "Article is not open to comments")
-    false
+    article.allow_comments?
   end
 
   def blog_allows_feedback?
     true
   end
 
-  def check_article_closed_for_feedback
-    errors.add(:article, "Comment are closed") if article.comments_closed?
+  def article_closed_for_feedback?
+    article.comments_closed?
   end
 
   def originator

--- a/publify_core/app/models/concerns/string_length_limit.rb
+++ b/publify_core/app/models/concerns/string_length_limit.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module StringLengthLimit
+  # Default string length limit for model attributes. When running on MySQL,
+  # this is equal to the default string length in the database as set by Rails.
+  STRING_LIMIT = 255
+
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def validates_default_string_length(*names)
+      names.each do |name|
+        validates name, length: { maximum: STRING_LIMIT }
+      end
+    end
+  end
+end

--- a/publify_core/app/models/config_manager.rb
+++ b/publify_core/app/models/config_manager.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module ConfigManager
-  def self.append_features(base)
-    super
+  def self.included(base)
     base.extend(ClassMethods)
   end
 

--- a/publify_core/app/models/content.rb
+++ b/publify_core/app/models/content.rb
@@ -5,6 +5,7 @@ require "uri"
 
 class Content < ApplicationRecord
   include ContentBase
+  include StringLengthLimit
 
   belongs_to :user, optional: true, touch: true
   belongs_to :blog
@@ -37,6 +38,9 @@ class Content < ApplicationRecord
                             }
 
   serialize :whiteboard
+
+  validates_default_string_length :title, :author, :permalink, :name,
+                                  :post_type, :text_filter_name
 
   def author=(user)
     if user.respond_to?(:login)

--- a/publify_core/app/models/feedback.rb
+++ b/publify_core/app/models/feedback.rb
@@ -10,9 +10,15 @@ class Feedback < ApplicationRecord
 
   include PublifyGuid
   include ContentBase
+  include StringLengthLimit
 
   validate :feedback_allowed, on: :create
   validates :article, presence: true
+
+  validates_default_string_length :title, :author, :email, :url, :blog_name,
+                                  :user_agent, :text_filter_name
+
+  validates :ip, length: { maximum: 40 }
 
   before_save :correct_url, :classify_content
   before_create :create_guid

--- a/publify_core/app/models/ping.rb
+++ b/publify_core/app/models/ping.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 class Ping < ApplicationRecord
+  include StringLengthLimit
+
   belongs_to :article
+  validates_default_string_length :url
 end

--- a/publify_core/app/models/post_type.rb
+++ b/publify_core/app/models/post_type.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class PostType < ApplicationRecord
+  include StringLengthLimit
+
   validates :name, uniqueness: true
   validates :name, presence: true
   validate :name_is_not_read
+  validates_default_string_length :name, :permalink, :description
+
   before_save :sanitize_title
 
   def name_is_not_read

--- a/publify_core/app/models/redirect.rb
+++ b/publify_core/app/models/redirect.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 class Redirect < ApplicationRecord
+  include StringLengthLimit
+
   belongs_to :content, optional: true, touch: true
   belongs_to :blog
 
   validates :from_path, uniqueness: true
   validates :to_path, presence: true
   validates :blog, presence: true
+
+  validates_default_string_length :from_path, :to_path
 
   def full_to_path
     path = to_path

--- a/publify_core/app/models/resource.rb
+++ b/publify_core/app/models/resource.rb
@@ -4,9 +4,12 @@ require "carrierwave"
 require "carrierwave/orm/activerecord"
 
 class Resource < ApplicationRecord
+  include StringLengthLimit
   belongs_to :blog
   belongs_to :content, optional: true
 
   mount_uploader :upload, ResourceUploader
   validates :upload, presence: true
+
+  validates_default_string_length :mime
 end

--- a/publify_core/app/models/tag.rb
+++ b/publify_core/app/models/tag.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class Tag < ApplicationRecord
+  include StringLengthLimit
+
   belongs_to :blog
   has_and_belongs_to_many :contents, order: "created_at DESC"
 
   validates :name, uniqueness: { scope: :blog_id }
   validates :blog, presence: true
   validates :name, presence: true
+  validates_default_string_length :display_name
 
   before_validation :ensure_naming_conventions
 

--- a/publify_core/app/models/trackback.rb
+++ b/publify_core/app/models/trackback.rb
@@ -14,24 +14,6 @@ class Trackback < Feedback
     end
   end
 
-  def article_allows_feedback?
-    return true if article.allow_pings?
-
-    errors.add(:article, "Article is not pingable")
-    false
-  end
-
-  def blog_allows_feedback?
-    return true unless blog.global_pings_disable
-
-    errors.add(:base, "Pings are disabled")
-    false
-  end
-
-  def check_article_closed_for_feedback
-    errors.add(:article, "Pings are closed") if article.pings_closed?
-  end
-
   def originator
     blog_name
   end
@@ -46,5 +28,19 @@ class Trackback < Feedback
 
   def feed_title
     "Trackback from #{blog_name}: #{title} on #{article.title}"
+  end
+
+  private
+
+  def article_allows_feedback?
+    article.allow_pings?
+  end
+
+  def blog_allows_feedback?
+    !blog.global_pings_disable
+  end
+
+  def article_closed_for_feedback?
+    article.pings_closed?
   end
 end

--- a/publify_core/app/models/user.rb
+++ b/publify_core/app/models/user.rb
@@ -14,12 +14,14 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include ConfigManager
+  include StringLengthLimit
 
   before_validation :set_default_profile
 
   validates :login, uniqueness: true
   validates :email, :login, presence: true
   validates :login, length: { in: 3..40 }
+  validates_default_string_length :email, :text_filter_name
 
   belongs_to :resource, optional: true
   has_many :notifications, foreign_key: "notify_user_id"

--- a/publify_core/app/models/user.rb
+++ b/publify_core/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   validates :email, :login, presence: true
   validates :login, length: { in: 3..40 }
   validates_default_string_length :email, :text_filter_name
+  validates :name, length: { maximum: 2048 }
 
   belongs_to :resource, optional: true
   has_many :notifications, foreign_key: "notify_user_id"

--- a/publify_core/spec/models/blog_spec.rb
+++ b/publify_core/spec/models/blog_spec.rb
@@ -113,6 +113,10 @@ describe Blog, type: :model do
   describe "validations" do
     let(:blog) { described_class.new }
 
+    it "requires base url to not be too long" do
+      expect(blog).to validate_length_of(:base_url).is_at_most(255)
+    end
+
     it "requires blog name to not be too long" do
       expect(blog).to validate_length_of(:blog_name).is_at_most(256)
     end

--- a/publify_core/spec/models/content_spec.rb
+++ b/publify_core/spec/models/content_spec.rb
@@ -144,4 +144,32 @@ describe Content, type: :model do
       it { expect(content.author_name).to eq(author.login) }
     end
   end
+
+  describe "validations" do
+    let(:content) { described_class.new }
+
+    it "requires title to not be too long" do
+      expect(content).to validate_length_of(:title).is_at_most(255)
+    end
+
+    it "requires author to not be too long" do
+      expect(content).to validate_length_of(:author).is_at_most(255)
+    end
+
+    it "requires permalink to not be too long" do
+      expect(content).to validate_length_of(:permalink).is_at_most(255)
+    end
+
+    it "requires name to not be too long" do
+      expect(content).to validate_length_of(:name).is_at_most(255)
+    end
+
+    it "requires post_type to not be too long" do
+      expect(content).to validate_length_of(:post_type).is_at_most(255)
+    end
+
+    it "requires text_filter_name to not be too long" do
+      expect(content).to validate_length_of(:text_filter_name).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/feedback_spec.rb
+++ b/publify_core/spec/models/feedback_spec.rb
@@ -178,4 +178,40 @@ describe Feedback, type: :model do
       assert !@comment.published?
     end
   end
+
+  describe "validations" do
+    let(:feedback) { described_class.new }
+
+    it "requires title to not be too long" do
+      expect(feedback).to validate_length_of(:title).is_at_most(255)
+    end
+
+    it "requires author to not be too long" do
+      expect(feedback).to validate_length_of(:author).is_at_most(255)
+    end
+
+    it "requires email to not be too long" do
+      expect(feedback).to validate_length_of(:email).is_at_most(255)
+    end
+
+    it "requires url to not be too long" do
+      expect(feedback).to validate_length_of(:url).is_at_most(255)
+    end
+
+    it "requires ip to not be too long" do
+      expect(feedback).to validate_length_of(:ip).is_at_most(40)
+    end
+
+    it "requires blog_name to not be too long" do
+      expect(feedback).to validate_length_of(:blog_name).is_at_most(255)
+    end
+
+    it "requires user_agent to not be too long" do
+      expect(feedback).to validate_length_of(:user_agent).is_at_most(255)
+    end
+
+    it "requires text_filter_name to not be too long" do
+      expect(feedback).to validate_length_of(:text_filter_name).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/ping_spec.rb
+++ b/publify_core/spec/models/ping_spec.rb
@@ -3,4 +3,11 @@
 require "rails_helper"
 
 describe Ping, type: :model do
+  describe "validations" do
+    let(:ping) { described_class.new }
+
+    it "requires url to not be too long" do
+      expect(ping).to validate_length_of(:url).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/post_type_spec.rb
+++ b/publify_core/spec/models/post_type_spec.rb
@@ -29,4 +29,20 @@ describe PostType, type: :model do
     expect(test_type).not_to be_valid
     expect(test_type.errors[:name]).to eq(["has already been taken"])
   end
+
+  describe "validations" do
+    let(:post_type) { described_class.new }
+
+    it "requires name to not be too long" do
+      expect(post_type).to validate_length_of(:name).is_at_most(255)
+    end
+
+    it "requires permalink to not be too long" do
+      expect(post_type).to validate_length_of(:permalink).is_at_most(255)
+    end
+
+    it "requires description to not be too long" do
+      expect(post_type).to validate_length_of(:description).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/redirect_spec.rb
+++ b/publify_core/spec/models/redirect_spec.rb
@@ -20,4 +20,16 @@ describe Redirect, type: :model do
       expect(redirect.from_url).to eq "#{blog.base_url}/right/here"
     end
   end
+
+  describe "validations" do
+    let(:redirect) { described_class.new }
+
+    it "requires from_path to not be too long" do
+      expect(redirect).to validate_length_of(:from_path).is_at_most(255)
+    end
+
+    it "requires to_path to not be too long" do
+      expect(redirect).to validate_length_of(:to_path).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/resource_spec.rb
+++ b/publify_core/spec/models/resource_spec.rb
@@ -33,4 +33,12 @@ describe Resource, type: :model do
       expect(img_resource.upload_url(:thumb)).to eq "/files/resource/1/thumb_testfile.png"
     end
   end
+
+  describe "validations" do
+    let(:resource) { described_class.new }
+
+    it "requires mime to not be too long" do
+      expect(resource).to validate_length_of(:mime).is_at_most(255)
+    end
+  end
 end

--- a/publify_core/spec/models/tag_spec.rb
+++ b/publify_core/spec/models/tag_spec.rb
@@ -12,9 +12,15 @@ describe Tag, type: :model do
     expect(test_tag.errors[:name]).to eq(["has already been taken"])
   end
 
-  describe "validation" do
+  describe "validations" do
+    let(:tag) { described_class.new }
+
     it "requires name to be present" do
-      expect(blog.tags.build(name: "")).not_to be_valid
+      expect(tag).to validate_presence_of(:name)
+    end
+
+    it "requires display_name to not be too long" do
+      expect(tag).to validate_length_of(:display_name).is_at_most(255)
     end
   end
 

--- a/publify_core/spec/models/trackback_spec.rb
+++ b/publify_core/spec/models/trackback_spec.rb
@@ -4,57 +4,85 @@ require "rails_helper"
 require "publify_core/testing_support/dns_mock"
 
 describe Trackback, type: :model do
-  let(:article) { create(:article) }
+  describe "validations" do
+    let(:blog) { build_stubbed :blog }
+    let(:trackback) { described_class.new }
 
-  before do
-    @blog = create(:blog)
-    @blog.sp_global = true
-    @blog.default_moderate_comments = false
-    @blog.save!
+    it "allows an article with open trackback window" do
+      article = Article.new(blog: blog, allow_pings: true, state: "published",
+                            published_at: 1.day.ago)
+
+      expect(trackback).to allow_value(article).for(:article)
+    end
+
+    it "requires article trackback window to be open" do
+      article = Article.new(blog: blog, allow_pings: true)
+
+      expect(trackback).not_to allow_value(article).for(:article).
+        with_message("Trackbacks are closed")
+    end
+
+    it "requires article to be open to trackback" do
+      article = Article.new(blog: blog, allow_pings: false)
+
+      expect(trackback).not_to allow_value(article).for(:article).
+        with_message("Article is not open for trackbacks")
+    end
   end
 
-  it "Incomplete trackbacks should not be accepted" do
-    tb = described_class.new(blog_name: "Blog name",
-                             title: "Title",
-                             excerpt: "Excerpt",
-                             article_id: create(:article).id)
-    expect(tb).not_to be_valid
-    expect(tb.errors["url"]).to be_any
-  end
+  describe "spam detection" do
+    let(:article) { create(:article) }
 
-  it "A valid trackback should be accepted" do
-    tb = described_class.new(blog_name: "Blog name",
-                             title: "Title",
-                             url: "http://foo.com",
-                             excerpt: "Excerpt",
-                             article_id: create(:article).id)
-    expect(tb).to be_valid
-    tb.save
-    expect(tb.guid.size).to be > 15
-    expect(tb).not_to be_spam
-  end
+    before do
+      @blog = create(:blog)
+      @blog.sp_global = true
+      @blog.default_moderate_comments = false
+      @blog.save!
+    end
 
-  it "Trackbacks with a spammy link in the excerpt should be rejected" do
-    tb = article.trackbacks.
-      build(ham_params.merge(excerpt: '<a href="http://chinaaircatering.com">spam</a>'))
-    tb.classify_content
-    expect(tb).to be_spammy
-  end
+    it "Incomplete trackbacks should not be accepted" do
+      tb = described_class.new(blog_name: "Blog name",
+                               title: "Title",
+                               excerpt: "Excerpt",
+                               article_id: create(:article).id)
+      expect(tb).not_to be_valid
+      expect(tb.errors["url"]).to be_any
+    end
 
-  it "Trackbacks with a spammy source url should be rejected" do
-    tb = article.trackbacks.build(ham_params.merge(url: "http://www.chinaircatering.com"))
-    tb.classify_content
-    expect(tb).to be_spammy
-  end
+    it "A valid trackback should be accepted" do
+      tb = described_class.new(blog_name: "Blog name",
+                               title: "Title",
+                               url: "http://foo.com",
+                               excerpt: "Excerpt",
+                               article_id: create(:article).id)
+      expect(tb).to be_valid
+      tb.save
+      expect(tb.guid.size).to be > 15
+      expect(tb).not_to be_spam
+    end
 
-  it "Trackbacks from a spammy ip address should be rejected" do
-    tb = article.trackbacks.build(ham_params.merge(ip: "212.42.230.207"))
-    tb.classify_content
-    expect(tb).to be_spammy
-  end
+    it "Trackbacks with a spammy link in the excerpt should be rejected" do
+      tb = article.trackbacks.
+        build(ham_params.merge(excerpt: '<a href="http://chinaaircatering.com">spam</a>'))
+      tb.classify_content
+      expect(tb).to be_spammy
+    end
 
-  def ham_params
-    { blog_name: "Blog", title: "trackback", excerpt: "bland",
-      url: "http://notaspammer.com", ip: "212.42.230.206" }
+    it "Trackbacks with a spammy source url should be rejected" do
+      tb = article.trackbacks.build(ham_params.merge(url: "http://www.chinaircatering.com"))
+      tb.classify_content
+      expect(tb).to be_spammy
+    end
+
+    it "Trackbacks from a spammy ip address should be rejected" do
+      tb = article.trackbacks.build(ham_params.merge(ip: "212.42.230.207"))
+      tb.classify_content
+      expect(tb).to be_spammy
+    end
+
+    def ham_params
+      { blog_name: "Blog", title: "trackback", excerpt: "bland",
+        url: "http://notaspammer.com", ip: "212.42.230.206" }
+    end
   end
 end

--- a/publify_core/spec/models/user_spec.rb
+++ b/publify_core/spec/models/user_spec.rb
@@ -49,6 +49,10 @@ describe User, type: :model do
       expect(user).to validate_length_of(:email).is_at_most(255)
     end
 
+    it "requires name to not be too long" do
+      expect(user).to validate_length_of(:name).is_at_most(2048)
+    end
+
     it "requires first name to not be too long" do
       expect(user).to validate_length_of(:firstname).is_at_most(256)
     end

--- a/publify_core/spec/models/user_spec.rb
+++ b/publify_core/spec/models/user_spec.rb
@@ -45,6 +45,10 @@ describe User, type: :model do
   describe "validations" do
     let(:user) { described_class.new }
 
+    it "requires email to not be too long" do
+      expect(user).to validate_length_of(:email).is_at_most(255)
+    end
+
     it "requires first name to not be too long" do
       expect(user).to validate_length_of(:firstname).is_at_most(256)
     end
@@ -71,6 +75,10 @@ describe User, type: :model do
 
     it "requires the login field to be present" do
       expect(user).to validate_presence_of(:login)
+    end
+
+    it "requires text_filter_name to not be too long" do
+      expect(user).to validate_length_of(:text_filter_name).is_at_most(255)
     end
 
     it "does not allow duplicate logins when updating a user" do


### PR DESCRIPTION
- Use preferred method of taking action when ConfigManager is included
- Refactor Feedback validations
- Validate lengths of string attributes
- Validate length of user's name attribute
