### PR TITLE
Update RuboCop and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,10 @@ Layout/BeginEndAlignment:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Lenient line length that fits in pull requests
 Layout/LineLength:
   Max: 92

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development, :test do
   gem "pry", "~> 0.14.0"
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 5.0"
-  gem "rubocop", "~> 1.22.3", require: false
+  gem "rubocop", "~> 1.35.0", require: false
   gem "rubocop-performance", "~> 1.12.0", require: false
   gem "rubocop-rails", "~> 2.12.4", require: false
   gem "rubocop-rspec", "~> 2.6.0", require: false

--- a/publify_amazon_sidebar/.rubocop.yml
+++ b/publify_amazon_sidebar/.rubocop.yml
@@ -25,6 +25,10 @@ Layout/BeginEndAlignment:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Lenient line length that fits in pull requests
 Layout/LineLength:
   Max: 92

--- a/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar/publify_amazon_sidebar.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"
   s.add_development_dependency "sqlite3"
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/publify_core/.rubocop.yml
+++ b/publify_core/.rubocop.yml
@@ -25,6 +25,10 @@ Layout/BeginEndAlignment:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Lenient line length that fits in pull requests
 Layout/LineLength:
   Max: 92

--- a/publify_core/app/helpers/base_helper.rb
+++ b/publify_core/app/helpers/base_helper.rb
@@ -226,8 +226,8 @@ module BaseHelper
   #   show the excerpt, or else we show the body
   def fetch_html_content_for_feeds(item, this_blog)
     if item.password_protected?
-      "<p>This article is password protected. Please " \
-        "<a href='#{item.permalink_url}'>fill in your password</a> to read it</p>"
+      "<p>This article is password protected. Please" \
+        " <a href='#{item.permalink_url}'>fill in your password</a> to read it</p>"
     elsif this_blog.hide_extended_on_rss
       if item.excerpt? && !item.excerpt.empty?
         item.excerpt

--- a/publify_core/publify_core.gemspec
+++ b/publify_core/publify_core.gemspec
@@ -61,4 +61,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "timecop", "~> 0.9.1"
   s.add_development_dependency "webmock", "~> 3.3"
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/publify_core/spec/lib/theme_spec.rb
+++ b/publify_core/spec/lib/theme_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Theme, type: :model do
   describe "#description" do
     it "returns the contents of the corresponding markdown file" do
       markdown_file = PublifyCore::Engine.instance.root.join("themes/plain/about.markdown")
-      expect(default_theme.description).to eq File.open(markdown_file, &:read)
+      expect(default_theme.description).to eq File.read(markdown_file)
     end
   end
 

--- a/publify_core/spec/models/article_spec.rb
+++ b/publify_core/spec/models/article_spec.rb
@@ -689,8 +689,8 @@ RSpec.describe Article, type: :model do
 
   describe "save_attachments!" do
     it "calls save_attachment for each file given" do
-      first_file = OpenStruct.new
-      second_file = OpenStruct.new
+      first_file = Object.new
+      second_file = Object.new
       hash = { a_key: first_file, a_second_key: second_file }
       article = build(:article)
       expect(article).to receive(:save_attachment!).with(first_file)

--- a/publify_textfilter_code/.rubocop.yml
+++ b/publify_textfilter_code/.rubocop.yml
@@ -25,6 +25,10 @@ Layout/BeginEndAlignment:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Lenient line length that fits in pull requests
 Layout/LineLength:
   Max: 92

--- a/publify_textfilter_code/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code/publify_textfilter_code.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "simplecov", "~> 0.21.2"
   s.add_development_dependency "sqlite3"
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
+++ b/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe PublifyApp::Textfilter::Code, type: :model do
 
           it "parses ruby and xml in same sentence but not in same place" do
             result = filter.
-              filter_text('<publify:code lang="ruby">foo-code</publify:code> ' \
-                          'blah blah <publify:code lang="xml">zzz</publify:code>')
+              filter_text('<publify:code lang="ruby">foo-code</publify:code>' \
+                          ' blah blah <publify:code lang="xml">zzz</publify:code>')
             expect(result).
               to eq '<div class="CodeRay"><pre><span class="CodeRay">' \
                     "foo-code</span></pre></div> blah blah" \

--- a/spec/lib/publify_textfilter_flickr_spec.rb
+++ b/spec/lib/publify_textfilter_flickr_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe "the Flickr text filter plugin", type: :model do
         '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
         '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
         ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-        "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-        "Ruby's creator</p></div>"
+        "<p class=\"caption\" style=\"width:75px\">This is Matz," \
+        " Ruby's creator</p></div>"
     end
 
     it "uses default image size" do
@@ -91,8 +91,8 @@ RSpec.describe "the Flickr text filter plugin", type: :model do
         '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
         '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
         ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-        "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-        "Ruby's creator</p></div>"
+        "<p class=\"caption\" style=\"width:75px\">This is Matz," \
+        " Ruby's creator</p></div>"
     end
 
     it "uses caption" do
@@ -124,8 +124,8 @@ RSpec.describe "the Flickr text filter plugin", type: :model do
         '<a href="http://www.flickr.com/users/scottlaird/31366117">' \
         '<img src="//photos23.flickr.com/31366117_b1a791d68e_s.jpg"' \
         ' width="75" height="75" alt="Matz" title="Matz"/></a>' \
-        "<p class=\"caption\" style=\"width:75px\">This is Matz, " \
-        "Ruby's creator</p></div>"
+        "<p class=\"caption\" style=\"width:75px\">This is Matz," \
+        " Ruby's creator</p></div>"
     end
   end
 end


### PR DESCRIPTION
- Update rubocop to version 1.35.0
- Configure Layout/LineContinuationLeadingSpace and fix related offenses
- Fix Style/FileRead offense
- Correct Gemspec/RequireMFA offenses
- Fix Style/OpenStructUse offenses
