### PR TITLE
Update rubocop-rails and fix new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development, :test do
   gem "rspec-rails", "~> 5.0"
   gem "rubocop", "~> 1.35.0", require: false
   gem "rubocop-performance", "~> 1.12.0", require: false
-  gem "rubocop-rails", "~> 2.12.4", require: false
+  gem "rubocop-rails", "~> 2.15.2", require: false
   gem "rubocop-rspec", "~> 2.6.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end

--- a/publify_core/app/controllers/admin/post_types_controller.rb
+++ b/publify_core/app/controllers/admin/post_types_controller.rb
@@ -16,7 +16,9 @@ class Admin::PostTypesController < Admin::BaseController
     @post_type = PostType.new(post_type_params)
 
     if @post_type.save
-      redirect_to admin_post_types_url, notice: "Post type was successfully created."
+      flash[:notice] = I18n.t("admin.base.successfully_created",
+                              name: PostType.model_name.human)
+      redirect_to admin_post_types_url
     else
       render :index
     end
@@ -24,7 +26,9 @@ class Admin::PostTypesController < Admin::BaseController
 
   def update
     if @post_type.update(post_type_params)
-      redirect_to admin_post_types_url, notice: "Post type was successfully updated."
+      flash[:notice] = I18n.t("admin.base.successfully_updated",
+                              name: PostType.model_name.human)
+      redirect_to admin_post_types_url
     else
       render :edit
     end
@@ -40,7 +44,9 @@ class Admin::PostTypesController < Admin::BaseController
       end
       @post_type.destroy
     end
-    redirect_to admin_post_types_url, notice: "Post was successfully destroyed."
+    flash[:notice] = I18n.t("admin.base.successfully_deleted",
+                            name: PostType.model_name.human)
+    redirect_to admin_post_types_url
   end
 
   private

--- a/publify_core/app/controllers/admin/redirects_controller.rb
+++ b/publify_core/app/controllers/admin/redirects_controller.rb
@@ -18,7 +18,9 @@ class Admin::RedirectsController < Admin::BaseController
     @redirect = this_blog.redirects.build(redirect_params)
 
     if @redirect.save
-      redirect_to admin_redirects_url, notice: "Redirect was successfully created."
+      flash[:notice] = I18n.t("admin.base.successfully_created",
+                              name: Redirect.model_name.human)
+      redirect_to admin_redirects_url
     else
       render :index
     end
@@ -26,7 +28,9 @@ class Admin::RedirectsController < Admin::BaseController
 
   def update
     if @redirect.update(redirect_params)
-      redirect_to admin_redirects_url, notice: "Redirect was successfully updated."
+      flash[:notice] = I18n.t("admin.base.successfully_updated",
+                              name: Redirect.model_name.human)
+      redirect_to admin_redirects_url
     else
       render :edit
     end

--- a/publify_core/app/controllers/admin/tags_controller.rb
+++ b/publify_core/app/controllers/admin/tags_controller.rb
@@ -14,7 +14,9 @@ class Admin::TagsController < Admin::BaseController
     @tag = this_blog.tags.new(tag_params)
 
     if @tag.save
-      redirect_to admin_tags_url, notice: "Tag was successfully created."
+      flash[:notice] = I18n.t("admin.base.successfully_created",
+                              name: PostType.model_name.human)
+      redirect_to admin_tags_url
     else
       fetch_tags
       render :index

--- a/publify_core/app/controllers/admin/users_controller.rb
+++ b/publify_core/app/controllers/admin/users_controller.rb
@@ -29,7 +29,9 @@ class Admin::UsersController < Admin::BaseController
 
   def update
     if @user.update(update_params)
-      redirect_to admin_users_url, notice: "User was successfully updated."
+      flash[:notice] = I18n.t("admin.base.successfully_updated",
+                              name: User.model_name.human)
+      redirect_to admin_users_url
     else
       render :edit
     end

--- a/publify_core/app/models/blog.rb
+++ b/publify_core/app/models/blog.rb
@@ -77,7 +77,7 @@ class Blog < ApplicationRecord
   setting :meta_keywords, :string, ""
   setting :google_analytics, :string, ""
   setting :rss_description, :boolean, false
-  setting :rss_description_text, :text, <<-HTML.strip_heredoc
+  setting :rss_description_text, :text, <<~HTML
     <hr />
     <p><small>Original article written by %author% and published on <a href='%blog_url%'>%blog_name%</a>
     | <a href='%permalink_url%'>direct link to this article</a>
@@ -86,7 +86,7 @@ class Blog < ApplicationRecord
   HTML
   setting :permalink_format, :string, "/%year%/%month%/%day%/%title%"
   setting :robots, :text, 'User-agent: *\nAllow: /\nDisallow: /admin\n'
-  setting :humans, :text, <<-TEXT.strip_heredoc
+  setting :humans, :text, <<~TEXT
     /* TEAM */
     Your title: Your name.
     Site: email, link to a contact form, etc.

--- a/publify_core/app/models/content.rb
+++ b/publify_core/app/models/content.rb
@@ -10,8 +10,6 @@ class Content < ApplicationRecord
   belongs_to :user, optional: true, touch: true
   belongs_to :blog
 
-  validates :blog, presence: true
-
   has_one :redirect, dependent: :destroy, inverse_of: :content
 
   has_many :triggers, as: :pending_item, dependent: :delete_all

--- a/publify_core/app/models/feedback.rb
+++ b/publify_core/app/models/feedback.rb
@@ -13,7 +13,6 @@ class Feedback < ApplicationRecord
   include StringLengthLimit
 
   validate :feedback_allowed, on: :create
-  validates :article, presence: true
 
   validates_default_string_length :title, :author, :email, :url, :blog_name,
                                   :user_agent, :text_filter_name

--- a/publify_core/app/models/redirect.rb
+++ b/publify_core/app/models/redirect.rb
@@ -8,7 +8,6 @@ class Redirect < ApplicationRecord
 
   validates :from_path, uniqueness: true
   validates :to_path, presence: true
-  validates :blog, presence: true
 
   validates_default_string_length :from_path, :to_path
 

--- a/publify_core/app/models/tag.rb
+++ b/publify_core/app/models/tag.rb
@@ -7,7 +7,6 @@ class Tag < ApplicationRecord
   has_and_belongs_to_many :contents, order: "created_at DESC"
 
   validates :name, uniqueness: { scope: :blog_id }
-  validates :blog, presence: true
   validates :name, presence: true
   validates_default_string_length :display_name
 

--- a/publify_core/config/locales/ar.yml
+++ b/publify_core/config/locales/ar.yml
@@ -81,7 +81,9 @@ ar:
         success: تم تحديث المقال بنجاح
     base:
       not_allowed: خطأ، غير مسموح لك بهذا الإجراء
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: "%{name} حُذفت بنجاح"
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: بواسطة

--- a/publify_core/config/locales/da.yml
+++ b/publify_core/config/locales/da.yml
@@ -81,7 +81,9 @@ da:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/de.yml
+++ b/publify_core/config/locales/de.yml
@@ -81,7 +81,9 @@ de:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/en.yml
+++ b/publify_core/config/locales/en.yml
@@ -81,7 +81,9 @@ en:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/es-MX.yml
+++ b/publify_core/config/locales/es-MX.yml
@@ -81,7 +81,9 @@ es-MX:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/fr.yml
+++ b/publify_core/config/locales/fr.yml
@@ -83,7 +83,9 @@ fr:
         success: Cet article a été mis à jour avec succès
     base:
       not_allowed: Erreur, vous n'êtes pas autorisé à réaliser cette action
+      successfully_created: "%{name} a été créé avec succès"
       successfully_deleted: "%{name} a été supprimé avec succès"
+      successfully_updated: "%{name} a été mis à jour avec succès"
     dashboard:
       comment:
         by: Par

--- a/publify_core/config/locales/he.yml
+++ b/publify_core/config/locales/he.yml
@@ -81,7 +81,9 @@ he:
         success: הכתבה עודכנה בהצלחה.
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: על ידי

--- a/publify_core/config/locales/it.yml
+++ b/publify_core/config/locales/it.yml
@@ -81,7 +81,9 @@ it:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/ja.yml
+++ b/publify_core/config/locales/ja.yml
@@ -81,7 +81,9 @@ ja:
         success: 記事が更新されました
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/lt.yml
+++ b/publify_core/config/locales/lt.yml
@@ -81,7 +81,9 @@ lt:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/nb.yml
+++ b/publify_core/config/locales/nb.yml
@@ -81,7 +81,9 @@ nb:
         success: Artikkel oppdatert
     base:
       not_allowed: Feil, du har ikke lov til å utføre denne handlingen
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: Slettet %{name}
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: Av

--- a/publify_core/config/locales/nl.yml
+++ b/publify_core/config/locales/nl.yml
@@ -81,7 +81,9 @@ nl:
         success: Artikel is succesvol bijgewerkt.
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} is met succes aangemaakt."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} is met succes bijgewerkt."
     dashboard:
       comment:
         by: Door

--- a/publify_core/config/locales/pl.yml
+++ b/publify_core/config/locales/pl.yml
@@ -81,7 +81,9 @@ pl:
         success: Artykuł został poprawnie zaktualizowany
     base:
       not_allowed: Błąd, nie masz wystarczających uprawnień aby to zrobić
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: "%{name} zostało pomyślnie usunięte"
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: Przez

--- a/publify_core/config/locales/pt-BR.yml
+++ b/publify_core/config/locales/pt-BR.yml
@@ -81,7 +81,9 @@ pt-BR:
         success: Artigo atualizado com sucesso
     base:
       not_allowed: Erro, você não possui permissão para executar esta ação
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: Este %{name} foi removido com sucesso
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: Por

--- a/publify_core/config/locales/ro.yml
+++ b/publify_core/config/locales/ro.yml
@@ -81,7 +81,9 @@ ro:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/ru.yml
+++ b/publify_core/config/locales/ru.yml
@@ -81,7 +81,9 @@ ru:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/zh-CN.yml
+++ b/publify_core/config/locales/zh-CN.yml
@@ -81,7 +81,9 @@ zh-CN:
         success: 文章更新成功
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/config/locales/zh-TW.yml
+++ b/publify_core/config/locales/zh-TW.yml
@@ -81,7 +81,9 @@ zh-TW:
         success: Article was successfully updated
     base:
       not_allowed: Error, you are not allowed to perform this action
+      successfully_created: "%{name} was successfully created."
       successfully_deleted: This %{name} was deleted successfully
+      successfully_updated: "%{name} was successfully updated."
     dashboard:
       comment:
         by: By

--- a/publify_core/spec/models/configuration_spec.rb
+++ b/publify_core/spec/models/configuration_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Given a new blog", type: :model do
 
   it "RSS description should be disable but not empty" do
     expect(blog).not_to be_rss_description
-    expect(blog.rss_description_text).to eq <<-HTML.strip_heredoc
+    expect(blog.rss_description_text).to eq <<~HTML
       <hr />
       <p><small>Original article written by %author% and published on <a href='%blog_url%'>%blog_name%</a>
       | <a href='%permalink_url%'>direct link to this article</a>

--- a/publify_core/spec/models/resource_spec.rb
+++ b/publify_core/spec/models/resource_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Resource, type: :model do
     end
 
     it "stores files in the correct location" do
-      expected_path = Rails.root.join("public/files/resource/1/testfile.txt")
+      expected_path = Rails.public_path.join("files/resource/1/testfile.txt")
       expect(resource.upload.file.file).to eq expected_path.to_s
     end
 
     it "stores resized images in the correct location" do
-      thumb_path = Rails.root.join("public/files/resource/1/thumb_testfile.png")
+      thumb_path = Rails.public_path.join("files/resource/1/thumb_testfile.png")
       expect(img_resource.upload.thumb.file.file).to eq thumb_path.to_s
     end
 

--- a/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
+++ b/publify_textfilter_code/spec/lib/publify_app/textfilter_code_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe PublifyApp::Textfilter::Code, type: :model do
     end
 
     it "test_code_plus_markup_chain" do
-      text = <<-MARKUP.strip_heredoc
+      text = <<~MARKUP
         *header text here*
 
         <publify:code lang="ruby">
@@ -83,7 +83,7 @@ RSpec.describe PublifyApp::Textfilter::Code, type: :model do
 
       MARKUP
 
-      expects_markdown = <<-HTML.strip_heredoc.strip
+      expects_markdown = <<~HTML.strip
         <p><em>header text here</em></p>
         <div class=\"CodeRay\"><pre><span class=\"CodeRay\"><span class=\"keyword\">class</span> <span class=\"class\">test</span>
           <span class=\"keyword\">def</span> <span class=\"function\">method</span>


### PR DESCRIPTION
- Update rubocop-rails to version 2.15.2
- Autocorrect Rails/StripHeredoc
- Autocorrect Rails/RootPublicPath
- Autocorrect Rails/RedundantPresenceValidationOnBelongsTo
- Localize remaining admin flash messages
