### PR TITLE
Update rubocop-rspec and fix new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem "rubocop", "~> 1.35.0", require: false
   gem "rubocop-performance", "~> 1.12.0", require: false
   gem "rubocop-rails", "~> 2.15.2", require: false
-  gem "rubocop-rspec", "~> 2.6.0", require: false
+  gem "rubocop-rspec", "~> 2.12.1", require: false
   gem "simplecov", "~> 0.21.2", require: false
 end
 

--- a/publify_core/.rubocop.yml
+++ b/publify_core/.rubocop.yml
@@ -101,7 +101,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/migrate/*'
 
-Capybara/FeatureMethods:
+RSpec/Capybara/FeatureMethods:
   Exclude:
     - 'spec/features/**_spec.rb'
 

--- a/publify_core/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/publify_core/spec/controllers/admin/dashboard_controller_spec.rb
@@ -23,59 +23,56 @@ RSpec.describe Admin::DashboardController, type: :controller do
     end
 
     it "has a link to the theme" do
-      expect(response.body).to have_selector("a[href='/admin/themes']",
-                                             text: "change your blog presentation")
+      expect(response.body).to have_link("change your blog presentation",
+                                         href: "/admin/themes")
     end
 
     it "has a link to the sidebar" do
-      expect(response.body).to have_selector("a[href='/admin/sidebar']",
-                                             text: "enable plugins")
+      expect(response.body).to have_link("enable plugins", href: "/admin/sidebar")
     end
 
     it "has a link to a new article" do
-      expect(response.body).to have_selector("a[href='/admin/articles/new']",
-                                             text: "write a post")
+      expect(response.body).to have_link("write a post", href: "/admin/articles/new")
     end
 
     it "has a link to a new page" do
-      expect(response.body).to have_selector("a[href='/admin/pages/new']",
-                                             text: "write a page")
+      expect(response.body).to have_link("write a page", href: "/admin/pages/new")
     end
 
     it "has a link to article listing" do
-      expect(response.body).to have_selector("a[href='/admin/articles']",
-                                             text: "no article")
+      expect(response.body).to have_link("no article", href: "/admin/articles")
     end
 
     it "has a link to user's article listing" do
       expect(response.body).
-        to have_selector("a[href='/admin/articles?search%5Buser_id%5D=#{@henri.id}']",
-                         text: "no article written by you")
+        to have_link("no article written by you",
+                     href: "/admin/articles?search%5Buser_id%5D=#{@henri.id}")
     end
 
     it "has a link to drafts" do
       expect(response.body).
-        to have_selector("a[href='/admin/articles?search%5Bstate%5D=drafts']",
-                         text: "no draft")
+        to have_link("no draft",
+                     href: "/admin/articles?search%5Bstate%5D=drafts")
     end
 
     it "has a link to pages" do
-      expect(response.body).to have_selector("a[href='/admin/pages']", text: "no page")
+      expect(response.body).to have_link("no page",
+                                         href: "/admin/pages")
     end
 
     it "has a link to total comments" do
-      expect(response.body).to have_selector("a[href='/admin/feedback']",
-                                             text: "no comment")
+      expect(response.body).to have_link("no comment",
+                                         href: "/admin/feedback")
     end
 
     it "has a link to Spam" do
-      expect(response.body).to have_selector("a[href='/admin/feedback?only=spam']",
-                                             text: "no spam")
+      expect(response.body).to have_link("no spam",
+                                         href: "/admin/feedback?only=spam")
     end
 
     it "has a link to Spam queue" do
-      expect(response.body).to have_selector("a[href='/admin/feedback?only=unapproved']",
-                                             text: "no unconfirmed")
+      expect(response.body).to have_link("no unconfirmed",
+                                         href: "/admin/feedback?only=unapproved")
     end
   end
 
@@ -92,49 +89,49 @@ RSpec.describe Admin::DashboardController, type: :controller do
     end
 
     it "does not have a link to the theme" do
-      expect(response.body).not_to have_selector("a[href='/admin/themes']",
-                                                 text: "change your blog presentation")
+      expect(response.body).not_to have_link("change your blog presentation",
+                                             href: "/admin/themes")
     end
 
     it "does not have a link to the sidebar" do
-      expect(response.body).not_to have_selector("a[href='/admin/sidebar']",
-                                                 text: "enable plugins")
+      expect(response.body).not_to have_link("enable plugins",
+                                             href: "/admin/sidebar")
     end
 
     it "has a link to a new article" do
-      expect(response.body).to have_selector("a[href='/admin/articles/new']",
-                                             text: "write a post")
+      expect(response.body).to have_link("write a post",
+                                         href: "/admin/articles/new")
     end
 
     it "has a link to a new page" do
-      expect(response.body).to have_selector("a[href='/admin/pages/new']",
-                                             text: "write a page")
+      expect(response.body).to have_link("write a page",
+                                         href: "/admin/pages/new")
     end
 
     it "has a link to article listing" do
-      expect(response.body).to have_selector("a[href='/admin/articles']",
-                                             text: "no article")
+      expect(response.body).to have_link("no article",
+                                         href: "/admin/articles")
     end
 
     it "has a link to user's article listing" do
       expect(response.body).
-        to have_selector("a[href='/admin/articles?search%5Buser_id%5D=#{@rene.id}']",
-                         text: "no article written by you")
+        to have_link("no article written by you",
+                     href: "/admin/articles?search%5Buser_id%5D=#{@rene.id}")
     end
 
     it "has a link to total comments" do
-      expect(response.body).to have_selector("a[href='/admin/feedback']",
-                                             text: "no comment")
+      expect(response.body).to have_link("no comment",
+                                         href: "/admin/feedback")
     end
 
     it "has a link to Spam" do
-      expect(response.body).to have_selector("a[href='/admin/feedback?only=spam']",
-                                             text: "no spam")
+      expect(response.body).to have_link("no spam",
+                                         href: "/admin/feedback?only=spam")
     end
 
     it "has a link to Spam queue" do
-      expect(response.body).to have_selector("a[href='/admin/feedback?only=unapproved']",
-                                             text: "no unconfirmed")
+      expect(response.body).to have_link("no unconfirmed",
+                                         href: "/admin/feedback?only=unapproved")
     end
   end
 
@@ -151,55 +148,55 @@ RSpec.describe Admin::DashboardController, type: :controller do
     end
 
     it "does not have a link to the theme" do
-      expect(response.body).not_to have_selector("a[href='/admin/themes']",
-                                                 text: "change your blog presentation")
+      expect(response.body).not_to have_link("change your blog presentation",
+                                             href: "/admin/themes")
     end
 
     it "does not have a link to the sidebar" do
-      expect(response.body).not_to have_selector("a[href='/admin/sidebar']",
-                                                 text: "enable plugins")
+      expect(response.body).not_to have_link("enable plugins",
+                                             href: "/admin/sidebar")
     end
 
     it "does not have a link to a new article" do
-      expect(response.body).not_to have_selector("a[href='/admin/articles/new']",
-                                                 text: "write a post")
+      expect(response.body).not_to have_link("write a post",
+                                             href: "/admin/articles/new")
     end
 
     it "does not have a link to a new article" do
-      expect(response.body).not_to have_selector("a[href='/admin/pages/new']",
-                                                 text: "write a page")
+      expect(response.body).not_to have_link("write a page",
+                                             href: "/admin/pages/new")
     end
 
     it "does not have a link to article listing" do
-      expect(response.body).not_to have_selector("a[href='/admin/articles']",
-                                                 text: "Total posts:")
+      expect(response.body).not_to have_link("Total posts:",
+                                             href: "/admin/articles")
     end
 
     it "does not have a link to user's article listing" do
       expect(response.body).
-        not_to have_selector("a[href='/admin/articles?search%5Buser_id%5D=#{@gerard.id}']",
-                             text: "Your posts:")
+        not_to have_link("Your posts:",
+                         href: "/admin/articles?search%5Buser_id%5D=#{@gerard.id}")
     end
 
     it "does not have a link to categories" do
-      expect(response.body).not_to have_selector("a[href='/admin/categories']",
-                                                 text: "Categories:")
+      expect(response.body).not_to have_link("Categories:",
+                                             href: "/admin/categories")
     end
 
     it "does not have a link to total comments" do
-      expect(response.body).not_to have_selector("a[href='/admin/feedback']",
-                                                 text: "Total comments:")
+      expect(response.body).not_to have_link("Total comments:",
+                                             href: "/admin/feedback")
     end
 
     it "does not have a link to Spam" do
-      expect(response.body).not_to have_selector("a[href='/admin/feedback?only=spam']",
-                                                 text: "no spam")
+      expect(response.body).not_to have_link("no spam",
+                                             href: "/admin/feedback?only=spam")
     end
 
     it "does not have a link to Spam queue" do
       expect(response.body).
-        not_to have_selector("a[href='/admin/feedback?only=unapproved']",
-                             text: "no unconfirmed")
+        not_to have_link("no unconfirmed",
+                         href: "/admin/feedback?only=unapproved")
     end
   end
 end

--- a/publify_core/spec/helpers/author_helper_spec.rb
+++ b/publify_core/spec/helpers/author_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AuthorsHelper, type: :helper do
     it "displays a link if the item is an url" do
       item = display_profile_item("http://twitter.com/mytwitter", "Twitter:")
       expect(item).to have_selector("li") do
-        have_selector("a", text: "http://twitter.com/mytwitter")
+        have_link("http://twitter.com/mytwitter")
       end
     end
   end

--- a/publify_core/spec/models/blog_spec.rb
+++ b/publify_core/spec/models/blog_spec.rb
@@ -165,42 +165,42 @@ RSpec.describe Blog, type: :model do
   describe "#has_twitter_configured?" do
     it "is false without :twitter_consumer_key or twitter_consumer_secret" do
       blog = build(:blog)
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with an empty :twitter_consumer_key and no twitter_consumer_secret" do
       blog = build(:blog, twitter_consumer_key: "")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with an empty twitter_consumer_key and an empty twitter_consumer_secret" do
       blog = build(:blog, twitter_consumer_key: "", twitter_consumer_secret: "")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_consumer_key and no twitter_consumer_secret" do
       blog = build(:blog, twitter_consumer_key: "12345")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_consumer_key and an empty twitter_consumer_secret" do
       blog = build(:blog, twitter_consumer_key: "12345", twitter_consumer_secret: "")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_consumer_secret and no twitter_consumer_key" do
       blog = build(:blog, twitter_consumer_secret: "67890")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_consumer_secret and an empty twitter_consumer_key" do
       blog = build(:blog, twitter_consumer_secret: "67890", twitter_consumer_key: "")
-      expect(blog.has_twitter_configured?).to eq(false)
+      expect(blog.has_twitter_configured?).to be(false)
     end
 
     it "is true with a twitter_consumer_key and a twitter_consumer_secret" do
       blog = build(:blog, twitter_consumer_key: "12345", twitter_consumer_secret: "67890")
-      expect(blog.has_twitter_configured?).to eq(true)
+      expect(blog.has_twitter_configured?).to be(true)
     end
   end
 

--- a/publify_core/spec/models/configuration_spec.rb
+++ b/publify_core/spec/models/configuration_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Given a new blog", type: :model do
 
   # Another clumsy setting name
   it "#global_pings_disable should be false" do
-    expect(blog.global_pings_disable).to eq(false)
+    expect(blog.global_pings_disable).to be(false)
     expect(blog).not_to be_global_pings_disable
   end
 
@@ -244,7 +244,7 @@ RSpec.describe "Given a new blog", type: :model do
   end
 
   it "a new blog should display statuses in the main feed" do
-    expect(blog.statuses_in_timeline).to eq(true)
+    expect(blog.statuses_in_timeline).to be(true)
   end
 end
 
@@ -356,6 +356,6 @@ RSpec.describe "Given a new status", type: :model do
   end
 
   it "does not have a reply context protected" do
-    expect(@note.in_reply_to_protected).to eq(false)
+    expect(@note.in_reply_to_protected).to be(false)
   end
 end

--- a/publify_core/spec/models/user_spec.rb
+++ b/publify_core/spec/models/user_spec.rb
@@ -171,42 +171,42 @@ RSpec.describe User, type: :model do
   describe "#has_twitter_configured?" do
     it "is false without twitter_oauth_token or twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: nil, twitter_oauth_token_secret: nil)
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with an empty twitter_oauth_token and no twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: "", twitter_oauth_token_secret: nil)
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with empty twitter_oauth_token and twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: "", twitter_oauth_token_secret: "")
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_oauth_token and no twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: "12345", twitter_oauth_token_secret: nil)
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_oauth_token and an empty twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: "12345", twitter_oauth_token_secret: "")
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_oauth_token_secret and no twitter_oauth_token" do
       user = build(:user, twitter_oauth_token: "", twitter_oauth_token_secret: "67890")
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is false with a twitter_oauth_token_secret and an empty twitter_oauth_token" do
       user = build(:user, twitter_oauth_token_secret: "67890", twitter_oauth_token: "")
-      expect(user.has_twitter_configured?).to eq(false)
+      expect(user.has_twitter_configured?).to be(false)
     end
 
     it "is true with a twitter_oauth_token and a twitter_oauth_token_secret" do
       user = build(:user, twitter_oauth_token: "12345", twitter_oauth_token_secret: "67890")
-      expect(user.has_twitter_configured?).to eq(true)
+      expect(user.has_twitter_configured?).to be(true)
     end
   end
 end


### PR DESCRIPTION
- Update rubocop-rspec to version 2.12.1
- Fix cop namespace for Capybara/FeatureMethods
- Autocorrect RSpec/BeEq
- Replace `have_selector` with more specific `have_link` where possible
