### PR TITLE
Fix article search rendering

### DIFF
--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -6,14 +6,9 @@ require "rails_helper"
 RSpec.describe ArticlesController, type: :controller do
   render_views
 
-  let(:blog) { create :blog }
-
   with_each_theme do |theme, _view_path|
     context "with theme #{theme}" do
-      before do
-        blog.theme = theme
-        blog.save!
-      end
+      let!(:blog) { create :blog, theme: theme }
 
       describe "#redirect" do
         let(:article) { create :article }

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -225,12 +225,10 @@ RSpec.describe ArticlesController, type: :controller do
                                       visible: :all)
         end
 
-        it "has content markdown interpret and without html tag" do
-          expect(response.body).to have_selector("div") do |div|
-            expect(div).
-              to match("in markdown format * we * use [ok](http://blog.ok.com)" \
-                       " to define a link")
-          end
+        it "renders content with markdown interpreted and html tags removed" do
+          expect(response.body).
+            to have_selector(
+              "div", text: /in markdown format\s+we\s+use\s+ok to define a link/)
         end
       end
 

--- a/themes/bootstrap-2/views/articles/search.html.erb
+++ b/themes/bootstrap-2/views/articles/search.html.erb
@@ -3,7 +3,9 @@
 <% @articles.each do |article| %>
 <div id="article-<%= article.id %>">
   <h2><%= link_to_permalink(article, article.title) %></h2>
-  <p><%= article.html(:body).strip_html.slice(0, 300) %> [...]</p>
+  <% if article.password.blank? %>
+    <p><%= article.html(:body).strip_html.slice(0, 300) %> [...]</p>
+  <% end %>
   <div class='author'>
     Le <%= l(article.published_at, format: :with_spaces) %>
   </div>

--- a/themes/bootstrap-2/views/articles/search.html.erb
+++ b/themes/bootstrap-2/views/articles/search.html.erb
@@ -3,7 +3,7 @@
 <% @articles.each do |article| %>
 <div id="article-<%= article.id %>">
   <h2><%= link_to_permalink(article, article.title) %></h2>
-  <p><%= article.body.strip_html.slice(0, 300) %> [...]</p>
+  <p><%= article.html(:body).strip_html.slice(0, 300) %> [...]</p>
   <div class='author'>
     Le <%= l(article.published_at, format: :with_spaces) %>
   </div>


### PR DESCRIPTION
- Fix rendering of article body in search results
- Test themes' search results rendering more thoroughly
- Hide protected article text from search result in bootstrap-2 theme
- Set theme when creating blog in ArticlesController specs
