### PR TITLE
Handle new rubocop-capybara offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_mode:
     - Exclude
 
 require:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ Rails:
 Bundler/DuplicatedGem:
   Enabled: false
 
+# Doesn't work well yet
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", "~> 6.0"
   gem "rubocop", "~> 1.56.0", require: false
+  gem "rubocop-capybara", "~> 2.19.0", require: false
   gem "rubocop-performance", "~> 1.19.0", require: false
   gem "rubocop-rails", "~> 2.21.0", require: false
   gem "rubocop-rspec", "~> 2.23.1", require: false

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe ArticlesController, type: :controller do
 
           it "has a good title" do
             expect(response.body).
-              to have_selector("title", text: "A big article | test blog",
-                                        visible: :all)
+              to have_css("title", text: "A big article | test blog",
+                                   visible: :all)
           end
         end
 
@@ -124,14 +124,14 @@ RSpec.describe ArticlesController, type: :controller do
 
           it "has good link feed rss" do
             expect(response.body).
-              to have_selector('head>link[href="http://test.host/articles.rss"]',
-                               visible: :all)
+              to have_css('head>link[href="http://test.host/articles.rss"]',
+                          visible: :all)
           end
 
           it "has good link feed atom" do
             expect(response.body).
-              to have_selector('head>link[href="http://test.host/articles.atom"]',
-                               visible: :all)
+              to have_css('head>link[href="http://test.host/articles.atom"]',
+                          visible: :all)
           end
 
           it "has a canonical url" do
@@ -141,7 +141,7 @@ RSpec.describe ArticlesController, type: :controller do
 
           it "has good title" do
             expect(response.body).
-              to have_selector("title", text: "test blog | test subtitle", visible: :all)
+              to have_css("title", text: "test blog | test subtitle", visible: :all)
           end
         end
 
@@ -174,7 +174,7 @@ RSpec.describe ArticlesController, type: :controller do
 
           it "has a good title" do
             expect(response.body).
-              to have_selector("title", text: "Archives for test blog", visible: :all)
+              to have_css("title", text: "Archives for test blog", visible: :all)
           end
         end
       end
@@ -198,7 +198,7 @@ RSpec.describe ArticlesController, type: :controller do
 
         it "renders content with markdown interpreted and html tags removed" do
           expect(response.body).
-            to have_selector(
+            to have_css(
               "div", text: /in markdown format\s+we\s+use\s+ok to define a link/)
         end
       end
@@ -230,16 +230,16 @@ RSpec.describe ArticlesController, type: :controller do
           get :search, params: { q: "oba" }
 
           expect(response.body).
-            to have_selector('head>link[href="http://test.host/search/oba.rss"]',
-                             visible: :all)
+            to have_css('head>link[href="http://test.host/search/oba.rss"]',
+                        visible: :all)
         end
 
         it "has good atom feed link" do
           get :search, params: { q: "oba" }
 
           expect(response.body).
-            to have_selector('head>link[href="http://test.host/search/oba.atom"]',
-                             visible: :all)
+            to have_css('head>link[href="http://test.host/search/oba.atom"]',
+                        visible: :all)
         end
 
         it "has a canonical url" do
@@ -254,8 +254,8 @@ RSpec.describe ArticlesController, type: :controller do
           get :search, params: { q: "oba" }
 
           expect(response.body).
-            to have_selector("title", text: "Results for oba | test blog",
-                                      visible: :all)
+            to have_css("title", text: "Results for oba | test blog",
+                                 visible: :all)
         end
 
         it "renders feed rss by search" do
@@ -294,7 +294,7 @@ RSpec.describe ArticlesController, type: :controller do
         end
 
         it "does not have h3 tag" do
-          expect(response.body).to have_selector("h3")
+          expect(response.body).to have_css("h3")
         end
       end
 
@@ -310,7 +310,7 @@ RSpec.describe ArticlesController, type: :controller do
             expect(response.body).
               to have_selector("head>link[href='#{blog.base_url}/archives']",
                                visible: :all).
-              and have_selector("title", text: "Archives for test blog", visible: :all)
+              and have_css("title", text: "Archives for test blog", visible: :all)
           end
 
           it "shows the current month only once" do

--- a/spec/views/comments/html_sanitization_spec.rb
+++ b/spec/views/comments/html_sanitization_spec.rb
@@ -41,20 +41,20 @@ RSpec.describe "comments/_comment.html.erb", type: :view do
             ActiveSupport::Deprecation.silence do
               render partial: "comments/comment", locals: { comment: @comment }
             end
-            expect(rendered).to have_selector(".content")
-            expect(rendered).to have_selector(".author")
+            expect(rendered).to have_css(".content")
+            expect(rendered).to have_css(".author")
 
-            expect(rendered).not_to have_selector(".content script")
-            expect(rendered).not_to have_selector(".content a:not([rel=nofollow])")
+            expect(rendered).not_to have_css(".content script")
+            expect(rendered).not_to have_css(".content a:not([rel=nofollow])")
             # No links with javascript
-            expect(rendered).not_to have_selector(".content a[onclick]")
-            expect(rendered).not_to have_selector('.content a[href^="javascript:"]')
+            expect(rendered).not_to have_css(".content a[onclick]")
+            expect(rendered).not_to have_css('.content a[href^="javascript:"]')
 
-            expect(rendered).not_to have_selector(".author script")
-            expect(rendered).not_to have_selector(".author a:not([rel=nofollow])")
+            expect(rendered).not_to have_css(".author script")
+            expect(rendered).not_to have_css(".author a:not([rel=nofollow])")
             # No links with javascript
-            expect(rendered).not_to have_selector(".author a[onclick]")
-            expect(rendered).not_to have_selector('.author a[href^="javascript:"]')
+            expect(rendered).not_to have_css(".author a[onclick]")
+            expect(rendered).not_to have_css('.author a[href^="javascript:"]')
           end
         end
       end
@@ -174,20 +174,20 @@ RSpec.describe "comments/_comment.html.erb", type: :view do
             ActiveSupport::Deprecation.silence do
               render partial: "comments/comment", locals: { comment: @comment }
             end
-            expect(rendered).to have_selector(".content")
-            expect(rendered).to have_selector(".author")
+            expect(rendered).to have_css(".content")
+            expect(rendered).to have_css(".author")
 
-            expect(rendered).not_to have_selector(".content script")
-            expect(rendered).not_to have_selector(".content a[rel=nofollow]")
+            expect(rendered).not_to have_css(".content script")
+            expect(rendered).not_to have_css(".content a[rel=nofollow]")
             # No links with javascript
-            expect(rendered).not_to have_selector(".content a[onclick]")
-            expect(rendered).not_to have_selector('.content a[href^="javascript:"]')
+            expect(rendered).not_to have_css(".content a[onclick]")
+            expect(rendered).not_to have_css('.content a[href^="javascript:"]')
 
-            expect(rendered).not_to have_selector(".author script")
-            expect(rendered).not_to have_selector(".author a[rel=nofollow]")
+            expect(rendered).not_to have_css(".author script")
+            expect(rendered).not_to have_css(".author a[rel=nofollow]")
             # No links with javascript
-            expect(rendered).not_to have_selector(".author a[onclick]")
-            expect(rendered).not_to have_selector('.author a[href^="javascript:"]')
+            expect(rendered).not_to have_css(".author a[onclick]")
+            expect(rendered).not_to have_css('.author a[href^="javascript:"]')
           end
         end
       end

--- a/spec/views/layouts/default_spec.rb
+++ b/spec/views/layouts/default_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe "layouts/default.html.erb", type: :view do
       it "has keyword meta tag when use_meta_keyword set to true" do
         create(:blog, use_meta_keyword: true)
         render
-        expect(rendered).to have_selector('head>meta[name="keywords"]', visible: :all)
+        expect(rendered).to have_css('head>meta[name="keywords"]', visible: :all)
       end
 
       it "does not have keyword meta tag when use_meta_keyword set to false" do
         create(:blog, use_meta_keyword: false)
         render
-        expect(rendered).not_to have_selector('head>meta[name="keywords"]', visible: :all)
+        expect(rendered).not_to have_css('head>meta[name="keywords"]', visible: :all)
       end
     end
   end


### PR DESCRIPTION
- Control rubocop-capybara version explicitly
- Autocorrect Capybara/RSpec/HaveSelector offenses
- Disable Capybara/ClickLinkOrButtonStyle cop
