### PR TITLE
Update text filters to work with the changed text filter plugin system

### DIFF
--- a/lib/publify_textfilter_flickr.rb
+++ b/lib/publify_textfilter_flickr.rb
@@ -2,7 +2,9 @@
 
 class PublifyApp
   class Textfilter
-    class Flickr < TextFilterPlugin::MacroPost
+    class Flickr < TextFilterPlugin
+      include TextFilterPlugin::MacroPost
+
       plugin_display_name "Flickr"
       plugin_description "Automatically generate image tags for Flickr images"
 

--- a/lib/publify_textfilter_lightbox.rb
+++ b/lib/publify_textfilter_lightbox.rb
@@ -2,7 +2,9 @@
 
 class PublifyApp
   class Textfilter
-    class Lightbox < TextFilterPlugin::MacroPost
+    class Lightbox < TextFilterPlugin
+      include TextFilterPlugin::MacroPost
+
       plugin_display_name "Lightbox"
       plugin_description "Automatically generate tags for images displayed in a lightbox"
 

--- a/spec/lib/text_filter_plugin_spec.rb
+++ b/spec/lib/text_filter_plugin_spec.rb
@@ -6,32 +6,28 @@ RSpec.describe TextFilterPlugin do
   describe ".available_filters" do
     subject { described_class.available_filters }
 
-    it { is_expected.to include(PublifyApp::Textfilter::Markdown) }
-    it { is_expected.to include(PublifyApp::Textfilter::Smartypants) }
-    it { is_expected.to include(PublifyApp::Textfilter::Htmlfilter) }
-    it { is_expected.to include(PublifyApp::Textfilter::Flickr) }
-    it { is_expected.to include(PublifyApp::Textfilter::Code) }
-    it { is_expected.to include(PublifyApp::Textfilter::Lightbox) }
-    it { is_expected.to include(PublifyApp::Textfilter::Twitterfilter) }
-    it { is_expected.not_to include(TextFilterPlugin::Markup) }
-    it { is_expected.not_to include(TextFilterPlugin::Macro) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPre) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPost) }
+    it "lists usable filters" do
+      expect(described_class.available_filters).to contain_exactly(
+        PublifyCore::TextFilter::None,
+        PublifyCore::TextFilter::Markdown,
+        PublifyCore::TextFilter::Smartypants,
+        PublifyCore::TextFilter::MarkdownSmartquotes,
+        PublifyCore::TextFilter::Twitterfilter,
+        PublifyApp::Textfilter::Htmlfilter,
+        PublifyApp::Textfilter::Flickr,
+        PublifyApp::Textfilter::Code,
+        PublifyApp::Textfilter::Lightbox)
+    end
   end
 
   describe ".macro_filters" do
     subject { described_class.macro_filters }
 
-    it { is_expected.not_to include(PublifyApp::Textfilter::Markdown) }
-    it { is_expected.not_to include(PublifyApp::Textfilter::Smartypants) }
-    it { is_expected.not_to include(PublifyApp::Textfilter::Htmlfilter) }
-    it { is_expected.to include(PublifyApp::Textfilter::Flickr) }
-    it { is_expected.to include(PublifyApp::Textfilter::Code) }
-    it { is_expected.to include(PublifyApp::Textfilter::Lightbox) }
-    it { is_expected.not_to include(PublifyApp::Textfilter::Twitterfilter) }
-    it { is_expected.not_to include(TextFilterPlugin::Markup) }
-    it { is_expected.not_to include(TextFilterPlugin::Macro) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPre) }
-    it { is_expected.not_to include(TextFilterPlugin::MacroPost) }
+    it "lists the macro filters" do
+      expect(described_class.macro_filters).to contain_exactly(
+        PublifyApp::Textfilter::Flickr,
+        PublifyApp::Textfilter::Code,
+        PublifyApp::Textfilter::Lightbox)
+    end
   end
 end


### PR DESCRIPTION
MacroPre is now a module that must be included.
