### PR TITLE
Allow starting the GitHub Actions workflow manually

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,6 +15,7 @@ name: CI
       - 9-2-stable
   schedule:
     - cron: '16 4 12 * *'
+  workflow_dispatch:
 
 jobs:
   test-postgresql:


### PR DESCRIPTION
This is useful if the workflow has been disabled due to inactivity.
