### PR TITLE
Fix build failure by requiring logger explictly

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,6 +45,8 @@ jobs:
         run: cp config/database.yml.postgresql config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
+        env:
+          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 
@@ -75,6 +77,8 @@ jobs:
         run: cp config/database.yml.mysql config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
+        env:
+          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 
@@ -98,6 +102,8 @@ jobs:
         run: cp config/database.yml.sqlite config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
+        env:
+          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the
   # background. Read more: https://github.com/rails/spring
   gem "spring", "~> 4.2.0"
-  gem "spring-commands-cucumber", "~> 1.0"
   gem "spring-commands-rspec", "~> 1.0"
 
   gem "fast_stack"

--- a/bin/cucumber
+++ b/bin/cucumber
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
-require 'bundler/setup'
-load Gem.bin_path('cucumber', 'cucumber')

--- a/bin/i18n-tasks
+++ b/bin/i18n-tasks
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+require 'logger'
+load Gem.bin_path('i18n-tasks', 'i18n-tasks')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
+require 'logger'
 require 'rails/commands'

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@
 
 require_relative "boot"
 
+# FIXME: remove when upgrading to Rails 7.1
+require "logger"
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems

--- a/lib/tasks/i18n.rake
+++ b/lib/tasks/i18n.rake
@@ -5,7 +5,7 @@ require "English"
 namespace :i18n do
   desc "Check translation health"
   task :health do
-    `i18n-tasks health`
+    `bin/i18n-tasks health`
     abort("Translation problems found") unless $CHILD_STATUS.success?
   end
 end


### PR DESCRIPTION
Rails before 7.1 needs logger to be pre-loaded. Also fixes an issue with migrations whose root cause is unclear.
