### PR TITLE
Remove unneeded env var from GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,8 +45,6 @@ jobs:
         run: cp config/database.yml.postgresql config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
-        env:
-          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 
@@ -77,8 +75,6 @@ jobs:
         run: cp config/database.yml.mysql config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
-        env:
-          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 
@@ -102,8 +98,6 @@ jobs:
         run: cp config/database.yml.sqlite config/database.yml
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
-        env:
-          RAILS_ENV: test
       - name: Run tests
         run: bundle exec rake
 


### PR DESCRIPTION
Setting RAILS_ENV is not needed.

This reverts commit 5c3d95411dc96c2c6ae32e8371087460e6e1a91c.
